### PR TITLE
fw_iptables.c: use libiptc instead of command iptables.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,32 +1,33 @@
 set(src_apfreewifidog
 	main.c
-    commandline.c 
+	commandline.c 
 	conf.c 
 	debug.c 
-    fw_iptables.c 
-    firewall.c 
-    gateway.c 
-    centralserver.c 
-    http.c 
-    auth.c 
-    client_list.c 
-    util.c 
-    wdctl_thread.c 
-    ping_thread.c 
-    safe.c 
-    httpd_thread.c 
-    simple_http.c 
-    pstring.c 
-    thread_pool.c 
-    ipset.c 
-    https_server.c 
+	fw3_iptc.c 
+	fw_iptables.c 
+	firewall.c 
+	gateway.c 
+	centralserver.c 
+	http.c 
+	auth.c 
+	client_list.c 
+	util.c 
+	wdctl_thread.c 
+	ping_thread.c 
+	safe.c 
+	httpd_thread.c 
+	simple_http.c 
+	pstring.c 
+	thread_pool.c 
+	ipset.c 
+	https_server.c 
 	https_common.c 
-    wd_util.c 
+	wd_util.c 
 	ezxml.c
 	openssl_hostname_validation.c
 	hostcheck.c
-    http_server.c
-    mqtt_thread.c
+	http_server.c
+	mqtt_thread.c
 )
 
 set(src_wdctl wdctl.c util.c debug.c)
@@ -45,17 +46,21 @@ set(libs
 	event_openssl
 	mosquitto)
 
+set(fw3_libs
+	dl
+	iptext
+	iptext4
+	xtables)
+
 ADD_DEFINITIONS(-O2 -Wall --std=gnu99 -Wmissing-declarations)
 
 include_directories(../libhttpd/)
 
-
 add_executable(wdctl ${src_wdctl})
 add_executable(wifidog ${src_apfreewifidog})
-target_link_libraries(wifidog ${libs})
+target_link_libraries(wifidog ${libs} ${fw3_libs})
 
 install(TARGETS wifidog wdctl
-        RUNTIME DESTINATION bin
+		RUNTIME DESTINATION bin
 )
 
-    

--- a/src/firewall.c
+++ b/src/firewall.c
@@ -269,7 +269,7 @@ void
 fw_set_authservers(void)
 {
     debug(LOG_INFO, "Setting the authservers list");
-    iptables_fw_set_authservers();
+    iptables_fw_set_authservers(NULL);
 }
 
 //>>>>> liudf added 20151224

--- a/src/fw3_iptc.c
+++ b/src/fw3_iptc.c
@@ -1,0 +1,984 @@
+/* vim: set et sw=4 ts=4 sts=4 : */
+/********************************************************************\
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free:Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 59 Temple Place - Suite 330        Fax:    +1-617-542-2652       *
+ * Boston, MA  02111-1307,  USA       gnu@gnu.org                   *
+ *                                                                  *
+ \********************************************************************/
+
+/** @internal
+  @file fw3_iptc.c
+  @brief firewall3 - 3rd OpenWrt firewall implementation
+  @author Copyright (C) 2013 Jo-Philipp Wich <jow@openwrt.org>
+  @author Copyright (C) 2017 ZengFei Zhang <zhangzengfei@kunteng.org>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <ctype.h>
+#include <err.h>
+#include <errno.h>
+#include <dlfcn.h>
+#include <getopt.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+
+#include <xtables.h>
+#include <libubox/list.h>
+
+#include "fw3_iptc.h"
+#include "debug.h"
+
+
+/* xtables interface */
+#if (XTABLES_VERSION_CODE >= 10)
+# include "xtables-10.h"
+#elif (XTABLES_VERSION_CODE == 5)
+# include "xtables-5.h" 
+#else
+# error "Unsupported xtables version"
+#endif
+
+
+static struct option base_opts[] = {
+	{ .name = "match",  .has_arg = 1, .val = 'm' },
+	{ .name = "jump",   .has_arg = 1, .val = 'j' },
+	{ NULL }
+};
+
+static struct xtables_globals xtg = {
+	.option_offset = 0,
+	.program_version = "4",
+	.orig_opts = base_opts,
+};
+
+const char *fw3_flag_names[] = {
+	"filter",
+	"nat",
+	"mangle",
+	"raw",
+};
+
+static const struct {
+    const char *name;
+    enum fw3_table opcode;
+} fw3_keywords[] = {
+	{"filter", FW3_TABLE_FILTER},
+	{"nat", FW3_TABLE_NAT},
+	{"mangle", FW3_TABLE_MANGLE},
+	{NULL, FW3_TABLE_RAW}
+};
+
+static bool
+is_chain(struct fw3_ipt_handle *h, const char *name)
+{
+	return iptc_is_chain(name, h->handle);
+}
+
+static bool
+bitlen2netmask(int bits, void *mask)
+{
+	struct in_addr *v4;
+
+	if (bits < -32 || bits > 32)
+		return false;
+
+	v4 = mask;
+	v4->s_addr = bits ? htonl(~((1 << (32 - abs(bits))) - 1)) : 0;
+
+	if (bits < 0)
+		v4->s_addr = ~v4->s_addr;
+
+	return true;
+}
+
+static bool
+load_extension(struct fw3_ipt_handle *h, const char *name)
+{
+	char path[256];
+	void *lib, **tmp;
+	const char *pfx = "libipt";
+
+	snprintf(path, sizeof(path), "/usr/lib/iptables/libxt_%s.so", name);
+	if (!(lib = dlopen(path, RTLD_NOW)))
+	{
+		snprintf(path, sizeof(path), "/usr/lib/iptables/%s_%s.so", pfx, name);
+		lib = dlopen(path, RTLD_NOW);
+	}
+
+	if (!lib)
+		return false;
+
+	tmp = realloc(h->libv, sizeof(lib) * (h->libc + 1));
+
+	if (!tmp)
+		return false;
+
+	h->libv = tmp;
+	h->libv[h->libc++] = lib;
+
+	return true;
+}
+
+static struct xtables_match *
+find_match(struct fw3_ipt_rule *r, const char *name)
+{
+	struct xtables_match *m;
+
+	m = xtables_find_match(name, XTF_DONT_LOAD, &r->matches);
+
+	if (!m && load_extension(r->h, name))
+		m = xtables_find_match(name, XTF_DONT_LOAD, &r->matches);
+
+	return m;
+}
+
+static void
+init_match(struct fw3_ipt_rule *r, struct xtables_match *m, bool no_clone)
+{
+	size_t s;
+	struct xtables_globals *g;
+
+	if (!m)
+		return;
+
+	s = XT_ALIGN(sizeof(struct xt_entry_match)) + m->size;
+
+	m->m = fw3_alloc(s);
+
+	fw3_xt_set_match_name(m);
+
+	m->m->u.user.revision = m->revision;
+	m->m->u.match_size = s;
+
+	/* free previous userspace data */
+	fw3_xt_free_match_udata(m);
+
+	if (m->init)
+		m->init(m->m);
+
+	/* don't merge options if no_clone is set and this match is a clone */
+	if (no_clone && (m == m->next))
+		return;
+
+	/* merge option table */
+	g = &xtg;
+	fw3_xt_merge_match_options(g, m);
+}
+
+static char *
+get_protoname(struct fw3_ipt_rule *r)
+{
+	const struct xtables_pprot *pp;
+
+	if (r->protocol)
+		for (pp = xtables_chain_protos; pp->name; pp++)
+			if (pp->num == r->protocol)
+				return (char *)pp->name;
+
+	return NULL;
+}
+
+static bool
+need_protomatch(struct fw3_ipt_rule *r, const char *pname)
+{
+	if (!pname)
+		return false;
+
+	if (!xtables_find_match(pname, XTF_DONT_LOAD, NULL))
+		return true;
+
+	return !r->protocol_loaded;
+}
+
+static struct xtables_match *
+load_protomatch(struct fw3_ipt_rule *r)
+{
+	const char *pname = get_protoname(r);
+
+	if (!need_protomatch(r, pname))
+		return NULL;
+
+	return find_match(r, pname);
+}
+
+static struct xtables_target *
+fw3_find_target(struct fw3_ipt_rule *r, const char *name)
+{
+	struct xtables_target *t;
+
+	if (is_chain(r->h, name))
+		return xtables_find_target(XT_STANDARD_TARGET, XTF_LOAD_MUST_SUCCEED);
+
+	t = xtables_find_target(name, XTF_DONT_LOAD);
+
+	if (!t && load_extension(r->h, name))
+		t = xtables_find_target(name, XTF_DONT_LOAD);
+
+	return t;
+}
+
+static struct xtables_target *
+fw3_get_target(struct fw3_ipt_rule *r, const char *name)
+{
+	size_t s;
+	struct xtables_target *t;
+	struct xtables_globals *g;
+
+	t = fw3_find_target(r, name);
+
+	if (!t)
+		return NULL;
+
+	s = XT_ALIGN(sizeof(struct xt_entry_target)) + t->size;
+	t->t = fw3_alloc(s);
+
+	fw3_xt_set_target_name(t, name);
+
+	t->t->u.user.revision = t->revision;
+	t->t->u.target_size = s;
+
+	/* free previous userspace data */
+	fw3_xt_free_target_udata(t);
+
+	if (t->init)
+		t->init(t->t);
+
+	/* merge option table */
+	g = &xtg;
+	fw3_xt_merge_target_options(g, t);
+
+	r->target = t;
+
+	return t;
+}
+
+static char *
+fw3_strdup(const char *s)
+{
+	char *ns;
+
+	ns = strdup(s);
+
+	if (!ns)
+		debug(LOG_ERR, "Out of memory while duplicating string '%s'", s);
+
+	return ns;
+}
+
+void *
+fw3_alloc(size_t size)
+{
+	void *mem;
+
+	mem = calloc(1, size);
+
+	if (!mem)
+		debug(LOG_ERR, "Out of memory while allocating %d bytes", size);
+
+	return mem;
+}
+
+/* Can't be zero. */
+static int
+fw3_parse_rulenumber(const char *rule)
+{
+	unsigned int rulenum;
+
+	if (!xtables_strtoui(rule, NULL, &rulenum, 1, INT_MAX))
+		xtables_error(PARAMETER_PROBLEM,
+			   "Invalid rule number `%s'", rule);
+
+	return rulenum;
+}
+
+static bool
+fw3_parse_option(struct fw3_ipt_rule *r, int optc, bool inv)
+{
+	struct xtables_rule_match *m;
+	struct xtables_match *em;
+
+	/* is a target option */
+	if (r->target && fw3_xt_has_target_parse(r->target) &&
+		optc >= r->target->option_offset &&
+		optc < (r->target->option_offset + 256))
+	{
+		xtables_option_tpcall(optc, r->argv, inv, r->target, &r->e);
+		return false;
+	}
+
+	/* try to dispatch argument to one of the match parsers */
+	for (m = r->matches; m; m = m->next)
+	{
+		em = m->match;
+
+		if (m->completed || !fw3_xt_has_match_parse(em))
+			continue;
+
+		if (optc < em->option_offset ||
+			optc >= (em->option_offset + 256))
+			continue;
+
+		xtables_option_mpcall(optc, r->argv, inv, em, &r->e);
+		return false;
+	}
+
+	/* unhandled option, might belong to a protocol match */
+	if ((em = load_protomatch(r)) != NULL)
+	{
+		init_match(r, em, false);
+
+		r->protocol_loaded = true;
+		optind--;
+
+		return true;
+	}
+
+	if (optc == ':')
+		debug(LOG_WARNING, "fw3_parse_option(): option '%s' needs argument", r->argv[optind-1]);
+
+	if (optc == '?')
+		debug(LOG_WARNING, "fw3_parse_option(): unknown option '%s'", r->argv[optind-1]);
+
+	return false;
+}
+
+static bool
+fw3_parse_address(void *ptr, const char *val)
+{
+	struct fw3_address addr = { };
+	struct in_addr v4;
+	char *p = NULL, *m = NULL, *s, *e;
+	int bits = -1;
+
+	if (*val == '!')
+	{
+		addr.invert = true;
+		while (isspace(*++val));
+	}
+
+	s = strdup(val);
+
+	if (!s)
+		return false;
+
+	if ((m = strchr(s, '/')) != NULL)
+		*m++ = 0;
+	else if ((p = strchr(s, '-')) != NULL)
+		*p++ = 0;
+
+	if (inet_pton(AF_INET, s, &v4))
+	{
+		addr.address.v4 = v4;
+
+		if (m)
+		{
+			if (!inet_pton(AF_INET, m, &v4))
+			{
+				bits = strtol(m, &e, 10);
+
+				if ((*e != 0) || !bitlen2netmask(bits, &v4))
+					goto fail;
+			}
+
+			addr.mask.v4 = v4;
+		}
+		else if (p)
+		{
+			if (!inet_pton(AF_INET, p, &addr.mask.v4))
+				goto fail;
+
+			addr.range = true;
+		}
+		else
+		{
+			addr.mask.v4.s_addr = 0xFFFFFFFF;
+		}
+	}
+	else
+	{
+		goto fail;
+	}
+
+	free(s);
+	addr.set = true;
+	memcpy(ptr, &addr, sizeof(addr));
+	return true;
+
+fail:
+	free(s);
+	return false;
+}
+
+static void
+fw3_init_extensions(void)
+{
+	init_extensions();
+	init_extensions4();
+}
+
+static void *
+fw3_ipt_rule_build(struct fw3_ipt_rule *r)
+{
+	size_t s, target_size = (r->target) ? r->target->t->u.target_size : 0;
+	struct xtables_rule_match *m;
+
+	struct ipt_entry *e;
+
+	s = XT_ALIGN(sizeof(struct ipt_entry));
+
+	for (m = r->matches; m; m = m->next)
+		s += m->match->m->u.match_size;
+
+	e = fw3_alloc(s + target_size);
+
+	memcpy(e, &r->e, sizeof(struct ipt_entry));
+
+	e->target_offset = s;
+	e->next_offset = s + target_size;
+
+	s = 0;
+
+	for (m = r->matches; m; m = m->next)
+	{
+		memcpy(e->elems + s, m->match->m, m->match->m->u.match_size);
+		s += m->match->m->u.match_size;
+	}
+
+	if (target_size)
+		memcpy(e->elems + s, r->target->t, target_size);
+
+	return e;
+}
+
+static struct fw3_ipt_rule *
+fw3_ipt_rule_new(struct fw3_ipt_handle *h)
+{
+	struct fw3_ipt_rule *r;
+
+	r = fw3_alloc(sizeof(*r));
+
+	r->h = h;
+	r->argv = fw3_alloc(sizeof(char *));
+	r->argv[r->argc++] = "fw3";
+
+	return r;
+}
+
+static struct fw3_ipt_rule *
+fw3_ipt_rule_create(struct fw3_ipt_handle *handle, char *cmd)
+{
+	char *p, **tmp;
+	struct fw3_ipt_rule *r;
+
+	r = fw3_ipt_rule_new(handle);
+
+	for (p = strtok(cmd, " \t"); p; p = strtok(NULL, " \t"))
+	{
+		tmp = realloc(r->argv, (r->argc + 1) * sizeof(*r->argv));
+
+		if (!tmp)
+			break;
+
+		r->argv = tmp;
+		r->argv[r->argc++] = fw3_strdup(p);
+	}
+
+	return r;
+}
+
+static void
+fw3_ipt_rule_src_dest(struct fw3_ipt_rule *r,
+                      struct fw3_address *src, struct fw3_address *dest)
+{
+
+	if (src && src->set)
+	{
+		r->e.ip.src = src->address.v4;
+		r->e.ip.smsk = src->mask.v4;
+
+		r->e.ip.src.s_addr &= r->e.ip.smsk.s_addr;
+
+		if (src->invert)
+			r->e.ip.invflags |= IPT_INV_SRCIP;
+	}
+
+	if (dest && dest->set)
+	{
+		r->e.ip.dst = dest->address.v4;
+		r->e.ip.dmsk = dest->mask.v4;
+
+		r->e.ip.dst.s_addr &= r->e.ip.dmsk.s_addr;
+
+		if (dest->invert)
+			r->e.ip.invflags |= IPT_INV_DSTIP;
+	}
+}
+
+static void
+fw3_ipt_rule_address(struct fw3_ipt_rule *r, const char *address, bool dest)
+{
+	if (address)
+	{
+		struct fw3_address addr = { .set = true };
+		fw3_parse_address(&addr, address);
+		fw3_ipt_rule_src_dest(r, (dest) ? NULL : &addr, (dest) ? &addr : NULL);
+	}
+}
+
+static void
+fw3_ipt_rule_in_out(struct fw3_ipt_rule *r,
+                    struct fw3_device *in, struct fw3_device *out)
+{
+	if (in && !in->any)
+	{
+		xtables_parse_interface(in->name, r->e.ip.iniface,
+										  r->e.ip.iniface_mask);
+
+		if (in->invert)
+			r->e.ip.invflags |= IPT_INV_VIA_IN;
+	}
+
+	if (out && !out->any)
+	{
+		xtables_parse_interface(out->name, r->e.ip.outiface,
+										   r->e.ip.outiface_mask);
+
+		if (out->invert)
+			r->e.ip.invflags |= IPT_INV_VIA_OUT;
+	}
+}
+
+static void
+fw3_ipt_rule_device(struct fw3_ipt_rule *r, const char *device, bool out)
+{
+	if (device)
+	{
+		struct fw3_device dev = { .any = false };
+		strncpy(dev.name, device, sizeof(dev.name) - 1);
+		fw3_ipt_rule_in_out(r, (out) ? NULL : &dev, (out) ? &dev : NULL);
+	}
+}
+
+static void
+fw3_ipt_rule_proto(struct fw3_ipt_rule *r, const char* val)
+{
+	struct protoent *ent;
+
+	ent = getprotobyname(val);
+
+	if (ent)
+	{
+		r->e.ip.proto = ent->p_proto;
+
+		if (*val == '!')
+			r->e.ip.invflags |= XT_INV_PROTO;
+
+		r->protocol = ent->p_proto;
+	}
+}
+
+static unsigned char *
+fw3_ipt_rule_mask(struct fw3_ipt_rule *r)
+{
+	size_t s;
+	unsigned char *p, *mask = NULL;
+	struct xtables_rule_match *m;
+
+#define SZ(x) XT_ALIGN(sizeof(struct x))
+
+	s = SZ(ipt_entry);
+
+	for (m = r->matches; m; m = m->next)
+		s += SZ(ipt_entry_match) + m->match->size;
+
+	s += SZ(ipt_entry_target);
+	if (r->target)
+		s += r->target->size;
+
+	mask = fw3_alloc(s);
+	memset(mask, 0xFF, SZ(ipt_entry));
+	p = mask + SZ(ipt_entry);
+
+	for (m = r->matches; m; m = m->next)
+	{
+		memset(p, 0xFF, SZ(ipt_entry_match) + m->match->userspacesize);
+		p += SZ(ipt_entry_match) + m->match->size;
+	}
+
+	memset(p, 0xFF, SZ(ipt_entry_target) + (r->target) ? r->target->userspacesize : 0);
+
+	return mask;
+}
+
+static int
+fw3_ipt_create_chain(struct fw3_ipt_handle *h, const char *chain)
+{
+	int rv = iptc_create_chain(chain, h->handle);
+	if (!rv)
+		debug(LOG_ERR, "iptc_create_chain(): %s\n", iptc_strerror(errno));
+	
+	return rv;
+}
+
+static int
+fw3_ipt_flush_chain(struct fw3_ipt_handle *h, const char *chain)
+{
+	int rv = iptc_flush_entries(chain, h->handle);
+	if (!rv)
+		debug(LOG_ERR, "iptc_create_chain(): %s\n", iptc_strerror(errno));
+	
+	return rv;
+}
+
+static int
+__fw3_ipt_delete_rules(struct fw3_ipt_handle *h, const char *target)
+{
+	unsigned int num;
+	const struct ipt_entry *e;
+	const char *chain;
+	const char *t;
+	bool found;
+
+	for (chain = iptc_first_chain(h->handle);
+		 chain != NULL;
+		 chain = iptc_next_chain(h->handle))
+	{
+		do {
+			found = false;
+
+			for (num = 0, e = iptc_first_rule(chain, h->handle);
+				 e != NULL;
+				 num++, e = iptc_next_rule(e, h->handle))
+			{
+				t = iptc_get_target(e, h->handle);
+
+				if (*t && !strcmp(t, target))
+				{
+					debug(LOG_DEBUG, "-D %s %u\n", chain, num + 1);
+
+					iptc_delete_num_entry(chain, num, h->handle);
+					found = true;
+					break;
+				}
+			}
+		} while (found);
+	}
+
+	return (found ? 1 : 0 );
+}
+
+static int
+fw3_ipt_delete_chain(struct fw3_ipt_handle *h, const char *chain)
+{
+	int rv;
+
+	__fw3_ipt_delete_rules(h, chain);
+
+	rv = iptc_delete_chain(chain, h->handle);
+	if (!rv)
+		debug(LOG_ERR, "iptc_delete_chain(): %s\n", iptc_strerror(errno));
+
+	return rv;
+}
+
+static int
+__fw3_ipt_rule_append(struct fw3_ipt_rule *r)
+{
+	void *rule;
+	int i, optc, rv = 0;
+	const char *chain = NULL;
+	unsigned char *mask;
+	char command = 'A';
+	unsigned int rule_num = 0;
+
+	bool inv = false;
+
+	struct xtables_rule_match *m;
+	struct xtables_match *em;
+	struct xtables_target *et;
+	struct xtables_globals *g;
+
+	struct fw3_ipt_handle *handle = NULL;
+
+	g = &xtg;
+	g->opts = g->orig_opts;
+
+	optind = 0;
+	opterr = 0;
+
+	while ((optc = getopt_long(r->argc, r->argv, "-:t:N:F:X:I:A:D:p:i:o:s:d:m:j:", g->opts,
+	                           NULL)) != -1)
+	{
+		switch (optc)
+		{
+		case 't':
+			if (!r->h)
+			{
+				enum fw3_table table = FW3_TABLE_FILTER;
+
+				for (i = 0; fw3_keywords[i].name; i++)
+					if (strcasecmp(optarg, fw3_keywords[i].name) == 0)
+						table = fw3_keywords[i].opcode;
+
+				handle = fw3_ipt_open(table);
+				if (handle)
+					r->h = handle;
+			}
+
+			break;
+
+		case 'N':
+			rv = fw3_ipt_create_chain(r->h, optarg);
+			goto free;
+
+		case 'F':
+			rv = fw3_ipt_flush_chain(r->h, optarg);
+			goto free;
+
+		case 'X':
+			rv = fw3_ipt_delete_chain(r->h, optarg);
+			goto free;
+
+		case 'I':
+		case 'A':
+		case 'D':
+			command = optc;
+			if (optc == 'I' || optc == 'D')
+			{
+				if (optind < r->argc && r->argv[optind][0] != '-'
+					&& r->argv[optind][0] != '!')
+					rule_num = fw3_parse_rulenumber(r->argv[optind++]);
+				else if (optc == 'I') rule_num = 1;
+			}
+
+			chain = optarg;
+			break;
+
+		case 'p':
+			fw3_ipt_rule_proto(r, optarg);
+			break;
+
+		case 'i':
+			fw3_ipt_rule_device(r, optarg, NULL);
+			break;
+
+		case 'o':
+			fw3_ipt_rule_device(r, optarg, true);
+			break;
+
+		case 's':
+			fw3_ipt_rule_address(r, optarg, NULL);
+			break;
+
+		case 'd':
+			fw3_ipt_rule_address(r, optarg, true);
+			break;
+
+		case 'm':
+			em = find_match(r, optarg);
+
+			if (!em)
+			{
+				debug(LOG_WARNING, "fw3_ipt_rule_append(): Can't find match '%s'", optarg);
+				goto free;
+			}
+
+			init_match(r, em, true);
+			break;
+
+		case 'j':
+			et = fw3_get_target(r, optarg);
+
+			if (!et)
+			{
+				debug(LOG_WARNING, "fw3_ipt_rule_append(): Can't find target '%s'", optarg);
+				goto free;
+			}
+
+			break;
+
+		case 1:
+			if ((optarg[0] == '!') && (optarg[1] == '\0'))
+			{
+				optarg[0] = '\0';
+				inv = true;
+				continue;
+			}
+
+			debug(LOG_WARNING, "fw3_ipt_rule_append(): Bad argument '%s'", optarg);
+			goto free;
+
+		default:
+			if (fw3_parse_option(r, optc, inv))
+				continue;
+			break;
+		}
+
+		inv = false;
+	}
+
+	for (m = r->matches; m; m = m->next)
+		xtables_option_mfcall(m->match);
+
+	if (r->target)
+		xtables_option_tfcall(r->target);
+
+	rule = fw3_ipt_rule_build(r);
+
+	if (command == 'A')
+	{
+		rv = iptc_append_entry(chain, rule, r->h->handle);
+		if (!rv)
+			debug(LOG_ERR, "iptc_append_entry(): %s\n", iptc_strerror(errno));
+	} 
+	else if (command == 'D')
+	{
+		if (rule_num > 0)
+		{
+			rv = iptc_delete_num_entry(chain, rule_num - 1, r->h->handle);
+			if (!rv)
+			debug(LOG_ERR, "iptc_delete_num_entry(): %s\n", iptc_strerror(errno));
+		}
+		else
+		{
+			mask = fw3_ipt_rule_mask(r);
+			while (iptc_delete_entry(chain, rule, mask, r->h->handle))
+			{
+				rv = 1;
+			}
+
+			free(mask);
+		}
+	}
+	else
+	{
+		rv = iptc_insert_entry(chain, rule, rule_num - 1, r->h->handle);
+		if (!rv)
+			debug(LOG_ERR, "iptc_insert_entry(): %s\n", iptc_strerror(errno));
+	}
+
+	free(rule);
+
+	goto free;
+
+free:
+	for (i = 1; i < r->argc; i++)
+		free(r->argv[i]);
+
+	free(r->argv);
+
+	xtables_rule_matches_free(&r->matches);
+
+	if (r->target)
+		free(r->target->t);
+
+	free(r);
+
+	/* reset all targets and matches */
+	for (em = xtables_matches; em; em = em->next)
+		em->mflags = 0;
+
+	for (et = xtables_targets; et; et = et->next)
+	{
+		et->tflags = 0;
+		et->used = 0;
+	}
+
+	xtables_free_opts(1);
+
+	if (handle)
+	{
+		fw3_ipt_commit(handle);
+		fw3_ipt_close(handle);
+	}
+
+	return rv;
+}
+
+struct fw3_ipt_handle *
+fw3_ipt_open(enum fw3_table table)
+{
+	struct fw3_ipt_handle *h;
+
+	h = fw3_alloc(sizeof(*h));
+
+	xtables_init();
+
+	h->table  = table;
+	h->handle = iptc_init(fw3_flag_names[table]);
+
+	xtables_set_params(&xtg);
+	xtables_set_nfproto(NFPROTO_IPV4);
+
+	if (!h->handle)
+	{
+		free(h);
+		return NULL;
+	}
+
+	fw3_xt_reset();
+	fw3_init_extensions();
+
+	return h;
+}
+
+void
+fw3_ipt_close(struct fw3_ipt_handle *h)
+{
+	if (h->libv)
+	{
+		while (h->libc > 0)
+		{
+			h->libc--;
+			dlclose(h->libv[h->libc]);
+		}
+
+		free(h->libv);
+	}
+
+	free(h);
+}
+
+int
+fw3_ipt_commit(struct fw3_ipt_handle *h)
+{
+	int rv;
+
+	rv = iptc_commit(h->handle);
+	if (!rv)
+		debug(LOG_ERR, "iptc_commit(): %s", iptc_strerror(errno));
+
+	return rv;
+}
+
+int
+fw3_ipt_rule_append(struct fw3_ipt_handle *handle, char *command)
+{
+	if (!command || !*command)
+		return 0;
+
+	struct fw3_ipt_rule *r;
+
+	r = fw3_ipt_rule_create(handle, command);
+
+	return __fw3_ipt_rule_append(r);
+}

--- a/src/fw3_iptc.h
+++ b/src/fw3_iptc.h
@@ -1,0 +1,115 @@
+/* vim: set et sw=4 ts=4 sts=4 : */
+/********************************************************************\
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free:Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 59 Temple Place - Suite 330        Fax:    +1-617-542-2652       *
+ * Boston, MA  02111-1307,  USA       gnu@gnu.org                   *
+ *                                                                  *
+ \********************************************************************/
+
+/** @internal
+  @file fw3_iptc.h
+  @brief libiptc api.
+  @author Copyright (C) 2013 Jo-Philipp Wich <jow@openwrt.org>
+  @author Copyright (C) 2017 ZengFei Zhang <zhangzengfei@kunteng.org>
+ */
+ 
+#ifndef __FW3_IPTABLES_H
+#define __FW3_IPTABLES_H
+
+#include <stdbool.h>
+#include <libiptc/libiptc.h>
+#include <iptables.h>
+
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <netinet/ether.h>
+
+/* libipt*ext.so interfaces */
+extern void init_extensions(void);
+extern void init_extensions4(void);
+
+enum fw3_table
+{
+	FW3_TABLE_FILTER = 0,
+	FW3_TABLE_NAT    = 1,
+	FW3_TABLE_MANGLE = 2,
+	FW3_TABLE_RAW    = 3,
+};
+
+struct fw3_ipt_handle
+{
+	enum fw3_table table;
+	void *handle;
+
+	int libc;
+	void **libv;
+};
+
+struct fw3_ipt_rule {
+	struct fw3_ipt_handle *h;
+	struct ipt_entry e;
+
+	struct xtables_rule_match *matches;
+	struct xtables_target *target;
+
+	int argc;
+	char **argv;
+
+	uint32_t protocol;
+	bool protocol_loaded;
+};
+
+struct fw3_device
+{
+	bool set;
+	bool any;
+	bool invert;
+	char name[32];
+	char network[32];
+};
+
+struct fw3_address
+{
+	bool set;
+	bool range;
+	bool invert;
+	bool resolved;
+	union {
+		struct in_addr v4;
+		struct ether_addr mac;
+	} address;
+	union {
+		struct in_addr v4;
+		struct ether_addr mac;
+	} mask;
+};
+
+void *
+fw3_alloc(size_t size);
+
+struct fw3_ipt_handle *
+fw3_ipt_open(enum fw3_table table);
+
+void
+fw3_ipt_close(struct fw3_ipt_handle *h);
+
+int
+fw3_ipt_commit(struct fw3_ipt_handle *h);
+
+int
+fw3_ipt_rule_append(struct fw3_ipt_handle *handle, char *command);
+
+#endif

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -54,6 +54,8 @@
 #include "wd_util.h"
 #include "ipset.h"
 
+#include "fw3_iptc.h"
+
 //>>> liudf added 20160127
 static FILE	*f_fw_init = NULL;
 static FILE	*f_fw_destroy = NULL;
@@ -73,9 +75,14 @@ static char *fw_allow_script	= "/tmp/fw_allow";
 
 //<<< liudf add end
 
-static int iptables_do_command(const char *format, ...);
 static char *iptables_compile(const char *, const char *, const t_firewall_rule *);
-static void iptables_load_ruleset(const char *, const char *, const char *);
+
+// Use libiptc instead command iptables by zhangzf, 20170413
+static int iptables_do_append_command(void *handle, const char *format, ...);
+static void iptables_load_ruleset(const char *, const char *, const char *, void *handle);
+
+#define iptables_do_command(...) \
+	iptables_do_append_command(NULL, __VA_ARGS__)
 
 /**
 Used to supress the error output of the firewall during destruction */
@@ -92,22 +99,22 @@ static int fw_quiet = 0;
 static void
 iptables_insert_gateway_id(char **input)
 {
-    char *token;
-    const s_config *config;
-    char *buffer;
+	char *token;
+	const s_config *config;
+	char *buffer;
 
-    if (strstr(*input, "$ID$") == NULL)
-        return;
+	if (strstr(*input, "$ID$") == NULL)
+		return;
 
-    while ((token = strstr(*input, "$ID$")) != NULL)
-        /* This string may look odd but it's standard POSIX and ISO C */
-        memcpy(token, "%1$s", 4);
+	while ((token = strstr(*input, "$ID$")) != NULL)
+		/* This string may look odd but it's standard POSIX and ISO C */
+		memcpy(token, "%1$s", 4);
 
-    config = config_get_config();
-    safe_asprintf(&buffer, *input, config->gw_interface);
+	config = config_get_config();
+	safe_asprintf(&buffer, *input, config->gw_interface);
 
-    free(*input);
-    *input = buffer;
+	free(*input);
+	*input = buffer;
 }
 
 int
@@ -119,7 +126,7 @@ add_mac_to_ipset(const char *name, const char *mac, int timeout)
  
 	ipset_name = safe_malloc(strlen(name) + 1);
 	memcpy(ipset_name, name, strlen(name));
-    iptables_insert_gateway_id(&ipset_name);
+	iptables_insert_gateway_id(&ipset_name);
 
 	int nret = add_to_ipset(ipset_name, mac, timeout);
 	free(ipset_name);
@@ -137,7 +144,7 @@ add_ip_to_ipset(const char *name, const char *ip, int remove)
  
 	ipset_name = safe_malloc(strlen(name) + 1);
 	memcpy(ipset_name, name, strlen(name));
-    iptables_insert_gateway_id(&ipset_name);
+	iptables_insert_gateway_id(&ipset_name);
 
 	int nret = add_to_ipset(ipset_name, ip, remove);
 	free(ipset_name);
@@ -155,7 +162,7 @@ iptables_flush_ipset(const char *name)
  
 	ipset_name = safe_malloc(strlen(name) + 1);
 	memcpy(ipset_name, name, strlen(name));
-    iptables_insert_gateway_id(&ipset_name);
+	iptables_insert_gateway_id(&ipset_name);
 
 	int nret = flush_ipset(ipset_name);
 	free(ipset_name);
@@ -167,38 +174,38 @@ iptables_flush_ipset(const char *name)
 static int
 ipset_do_command(const char *format, ...)
 {
-    va_list vlist;
-    char *fmt_cmd;
-    char *cmd;
-    int rc;
+	va_list vlist;
+	char *fmt_cmd;
+	char *cmd;
+	int rc;
 
-    va_start(vlist, format);
-    safe_vasprintf(&fmt_cmd, format, vlist);
-    va_end(vlist);
+	va_start(vlist, format);
+	safe_vasprintf(&fmt_cmd, format, vlist);
+	va_end(vlist);
 
-    safe_asprintf(&cmd, "ipset %s", fmt_cmd);
-    free(fmt_cmd);
+	safe_asprintf(&cmd, "ipset %s", fmt_cmd);
+	free(fmt_cmd);
 
-    iptables_insert_gateway_id(&cmd);
+	iptables_insert_gateway_id(&cmd);
 
-    debug(LOG_DEBUG, "Executing command: %s", cmd);
-	
+	debug(LOG_DEBUG, "Executing command: %s", cmd);
+
 	// liudf added 20160127
 	f_fw_script_write(cmd);
 
-    rc = execute(cmd, fw_quiet);
+	rc = execute(cmd, fw_quiet);
 
-    if (rc != 0) {
-        // If quiet, do not display the error
-        if (fw_quiet == 0)
-            debug(LOG_ERR, "ipset command failed(%d): %s", rc, cmd);
-        else if (fw_quiet == 1)
-            debug(LOG_DEBUG, "ipset command failed(%d): %s", rc, cmd);
-    }
+	if (rc != 0) {
+		// If quiet, do not display the error
+		if (fw_quiet == 0)
+			debug(LOG_ERR, "ipset command failed(%d): %s", rc, cmd);
+		else if (fw_quiet == 1)
+			debug(LOG_DEBUG, "ipset command failed(%d): %s", rc, cmd);
+	}
 
-    free(cmd);
+	free(cmd);
 
-    return rc;
+	return rc;
 }
 
 /** @internal
@@ -206,65 +213,64 @@ ipset_do_command(const char *format, ...)
 static void
 iptables_do_command_save(const char *format, ...)
 {
-    va_list vlist;
-    char *fmt_cmd;
-    char *cmd;
+	va_list vlist;
+	char *fmt_cmd;
+	char *cmd;
 
-    va_start(vlist, format);
-    safe_vasprintf(&fmt_cmd, format, vlist);
-    va_end(vlist);
+	va_start(vlist, format);
+	safe_vasprintf(&fmt_cmd, format, vlist);
+	va_end(vlist);
 
-    safe_asprintf(&cmd, "iptables %s", fmt_cmd);
-    free(fmt_cmd);
+	safe_asprintf(&cmd, "iptables %s", fmt_cmd);
+	free(fmt_cmd);
 
-    iptables_insert_gateway_id(&cmd);
+	iptables_insert_gateway_id(&cmd);
 
 	f_fw_script_write(cmd);
 
-    free(cmd);
+	free(cmd);
 }
 
 /** @internal 
  * */
 static int
-iptables_do_command(const char *format, ...)
+iptables_do_append_command(void *handle, const char *format, ...)
 {
-    va_list vlist;
-    char *fmt_cmd;
-    char *cmd;
-    int rc;
+	va_list vlist;
+	char *fmt_cmd;
+	char *cmd;
+	int rc;
 
-    va_start(vlist, format);
-    safe_vasprintf(&fmt_cmd, format, vlist);
-    va_end(vlist);
+	va_start(vlist, format);
+	safe_vasprintf(&fmt_cmd, format, vlist);
+	va_end(vlist);
 
-    safe_asprintf(&cmd, "iptables %s", fmt_cmd);
-    free(fmt_cmd);
+	iptables_insert_gateway_id(&fmt_cmd);
 
-    iptables_insert_gateway_id(&cmd);
+	safe_asprintf(&cmd, "iptables %s", fmt_cmd);
 
 	f_fw_script_write(cmd);
 	if(fw_quiet == 2) {
-    	debug(LOG_DEBUG, "fill file command: %s", cmd);
+		debug(LOG_DEBUG, "fill file command: %s", cmd);
 		free(cmd);
 		return 0;
 	}
 
-    debug(LOG_DEBUG, "Executing command: %s", cmd);
+	debug(LOG_DEBUG, "Executing command: %s", cmd);
 
-    rc = execute(cmd, fw_quiet);
+	rc = fw3_ipt_rule_append(handle, fmt_cmd);
 
-    if (rc != 0) {
-        // If quiet, do not display the error
-        if (fw_quiet == 0)
-            debug(LOG_ERR, "iptables command failed(%d): %s", rc, cmd);
-        else if (fw_quiet == 1)
-            debug(LOG_DEBUG, "iptables command failed(%d): %s", rc, cmd);
-    }
+	if (rc != 1) {
+		// If quiet, do not display the error
+		if (fw_quiet == 0)
+			debug(LOG_ERR, "iptables command failed(%d): %s", rc, cmd);
+		else if (fw_quiet == 1)
+			debug(LOG_DEBUG, "iptables command failed(%d): %s", rc, cmd);
+	}
 
-    free(cmd);
+	free(cmd);
 
-    return rc;
+	return rc;
 }
 
 /**
@@ -278,59 +284,59 @@ iptables_do_command(const char *format, ...)
 static char *
 iptables_compile(const char *table, const char *chain, const t_firewall_rule * rule)
 {
-    char command[MAX_BUF], *mode;
+	char command[MAX_BUF], *mode;
 
-    memset(command, 0, MAX_BUF);
-    mode = NULL;
+	memset(command, 0, MAX_BUF);
+	mode = NULL;
 
-    switch (rule->target) {
-    case TARGET_DROP:
-        if (strncmp(table, "nat", 3) == 0) {
-            free(mode);
-            return NULL;
-        }
-        mode = safe_strdup("DROP");
-        break;
-    case TARGET_REJECT:
-        if (strncmp(table, "nat", 3) == 0) {
-            free(mode);
-            return NULL;
-        }
-        mode = safe_strdup("REJECT");
-        break;
-    case TARGET_ACCEPT:
-        mode = safe_strdup("ACCEPT");
-        break;
-    case TARGET_LOG:
-        mode = safe_strdup("LOG");
-        break;
-    case TARGET_ULOG:
-        mode = safe_strdup("ULOG");
-        break;
-    }
+	switch (rule->target) {
+	case TARGET_DROP:
+		if (strncmp(table, "nat", 3) == 0) {
+			free(mode);
+			return NULL;
+		}
+		mode = safe_strdup("DROP");
+		break;
+	case TARGET_REJECT:
+		if (strncmp(table, "nat", 3) == 0) {
+			free(mode);
+			return NULL;
+		}
+		mode = safe_strdup("REJECT");
+		break;
+	case TARGET_ACCEPT:
+		mode = safe_strdup("ACCEPT");
+		break;
+	case TARGET_LOG:
+		mode = safe_strdup("LOG");
+		break;
+	case TARGET_ULOG:
+		mode = safe_strdup("ULOG");
+		break;
+	}
 
-    snprintf(command, sizeof(command), "-t %s -A %s ", table, chain);
-    if (rule->mask != NULL) {
-        if (rule->mask_is_ipset) {
-            snprintf((command + strlen(command)), (sizeof(command) -
-                                                   strlen(command)), "-m set --match-set %s dst ", rule->mask);
-        } else {
-            snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "-d %s ", rule->mask);
-        }
-    }
-    if (rule->protocol != NULL) {
-        snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "-p %s ", rule->protocol);
-    }
-    if (rule->port != NULL) {
-        snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "--dport %s ", rule->port);
-    }
-    snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "-j %s", mode);
+	snprintf(command, sizeof(command), "-t %s -A %s ", table, chain);
+	if (rule->mask != NULL) {
+		if (rule->mask_is_ipset) {
+			snprintf((command + strlen(command)), (sizeof(command) -
+												   strlen(command)), "-m set --match-set %s dst ", rule->mask);
+		} else {
+			snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "-d %s ", rule->mask);
+		}
+	}
+	if (rule->protocol != NULL) {
+		snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "-p %s ", rule->protocol);
+	}
+	if (rule->port != NULL) {
+		snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "--dport %s ", rule->port);
+	}
+	snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "-j %s", mode);
 
-    free(mode);
+	free(mode);
 
-    /* XXX The buffer command, an automatic variable, will get cleaned
-     * off of the stack when we return, so we strdup() it. */
-    return (safe_strdup(command));
+	/* XXX The buffer command, an automatic variable, will get cleaned
+	 * off of the stack when we return, so we strdup() it. */
+	return (safe_strdup(command));
 }
 
 /**
@@ -341,47 +347,51 @@ iptables_compile(const char *table, const char *chain, const t_firewall_rule * r
  * @arg chain IPTables chain the rules go into
  */
 static void
-iptables_load_ruleset(const char *table, const char *ruleset, const char *chain)
+iptables_load_ruleset(const char *table, const char *ruleset, const char *chain, void *handle)
 {
-    t_firewall_rule *rule;
-    char *cmd;
+	t_firewall_rule *rule;
+	char *cmd;
 
-    debug(LOG_DEBUG, "Load ruleset %s into table %s, chain %s", ruleset, table, chain);
+	debug(LOG_DEBUG, "Load ruleset %s into table %s, chain %s", ruleset, table, chain);
 
-    for (rule = get_ruleset(ruleset); rule != NULL; rule = rule->next) {
-        cmd = iptables_compile(table, chain, rule);
-        if (cmd != NULL) {
-            debug(LOG_DEBUG, "Loading rule \"%s\" into table %s, chain %s", cmd, table, chain);
-            iptables_do_command(cmd);
-        }
-        free(cmd);
-    }
+	for (rule = get_ruleset(ruleset); rule != NULL; rule = rule->next) {
+		cmd = iptables_compile(table, chain, rule);
+		if (cmd != NULL) {
+			debug(LOG_DEBUG, "Loading rule \"%s\" into table %s, chain %s", cmd, table, chain);
+			iptables_do_append_command(handle, cmd);
+		}
+		free(cmd);
+	}
 
-    debug(LOG_DEBUG, "Ruleset %s loaded into table %s, chain %s", ruleset, table, chain);
+	debug(LOG_DEBUG, "Ruleset %s loaded into table %s, chain %s", ruleset, table, chain);
 }
 
 void
 iptables_fw_clear_authservers(void)
 {
-    iptables_do_command("-t filter -F " CHAIN_AUTHSERVERS);
-    iptables_do_command("-t nat -F " CHAIN_AUTHSERVERS);
+	iptables_do_command("-t filter -F " CHAIN_AUTHSERVERS);
+	iptables_do_command("-t nat -F " CHAIN_AUTHSERVERS);
 }
 
 void
-iptables_fw_set_authservers(void)
+iptables_fw_set_authservers(void *handle)
 {
-    const s_config *config;
-    t_auth_serv *auth_server;
+	const s_config *config;
+	t_auth_serv *auth_server;
 
-    config = config_get_config();
+	config = config_get_config();
 
-    for (auth_server = config->auth_servers; auth_server != NULL; auth_server = auth_server->next) {
-        if (auth_server->last_ip && strcmp(auth_server->last_ip, "0.0.0.0") != 0) {
-            iptables_do_command("-t filter -A " CHAIN_AUTHSERVERS " -d %s -j ACCEPT", auth_server->last_ip);
-            iptables_do_command("-t nat -A " CHAIN_AUTHSERVERS " -d %s -j ACCEPT", auth_server->last_ip);
-        }
-    }
-
+	for (auth_server = config->auth_servers; auth_server != NULL; auth_server = auth_server->next) {
+		if (auth_server->last_ip && strcmp(auth_server->last_ip, "0.0.0.0") != 0) {
+			debug(LOG_DEBUG, "the last ip: %s", auth_server->last_ip);
+			if (handle) {
+				iptables_do_append_command(handle, "-A " CHAIN_AUTHSERVERS " -d %s -j ACCEPT", auth_server->last_ip);
+			} else {
+				iptables_do_command("-t filter -A " CHAIN_AUTHSERVERS " -d %s -j ACCEPT", auth_server->last_ip);
+				iptables_do_command("-t nat -A " CHAIN_AUTHSERVERS " -d %s -j ACCEPT", auth_server->last_ip);
+			}
+		}
+	}
 }
 
 // >>>liudf added 20151223
@@ -405,14 +415,14 @@ iptables_fw_set_user_domains_trusted(void)
 	const s_config *config;
 	t_domain_trusted *domain_trusted = NULL;
 
-    config = config_get_config();
-	
+	config = config_get_config();
+
 	LOCK_DOMAIN();
-		
+
 	for (domain_trusted = config->domains_trusted; domain_trusted != NULL; domain_trusted = domain_trusted->next) {
 		t_ip_trusted *ip_trusted = NULL;
 		for(ip_trusted = domain_trusted->ips_trusted; ip_trusted != NULL; ip_trusted = ip_trusted->next) {
-			add_ip_to_ipset(CHAIN_DOMAIN_TRUSTED, ip_trusted->ip, 0);	
+			add_ip_to_ipset(CHAIN_DOMAIN_TRUSTED, ip_trusted->ip, 0);
 		}
 	}
 
@@ -425,10 +435,10 @@ iptables_fw_clear_ipset_domains_trusted(void)
 {
 	char f_ipset_name[128] = {0};
 	snprintf(f_ipset_name, 128, "%s/%s", DNSMASQ_CONF_D, CHAIN_IPSET_TDOMAIN);
-	
+
 	remove(f_ipset_name);
 	iptables_flush_ipset(CHAIN_IPSET_TDOMAIN);
-	execute("/etc/init.d/dnsmasq restart", 1);		
+	execute("/etc/init.d/dnsmasq restart", 1);
 }
 
 void
@@ -438,11 +448,11 @@ iptables_fw_set_ipset_domains_trusted(void)
 	t_domain_trusted *domain_trusted = NULL;
 	FILE *fd_ipset = NULL;
 	char f_ipset_name[128] = {0};
-	int  has_content = 0;	
+	int  has_content = 0;
 
 	config = config_get_config();
-	
-	mkdir(DNSMASQ_CONF_D, S_IRWXU|S_IRWXG|S_IRWXO);	
+
+	mkdir(DNSMASQ_CONF_D, S_IRWXU|S_IRWXG|S_IRWXO);
 	snprintf(f_ipset_name, 128, "%s/%s", DNSMASQ_CONF_D, CHAIN_IPSET_TDOMAIN);
 	fd_ipset = fopen(f_ipset_name, "w");
 	if(fd_ipset == NULL) {
@@ -450,21 +460,21 @@ iptables_fw_set_ipset_domains_trusted(void)
 	}
 
 	LOCK_DOMAIN();
-	
+
 	for (domain_trusted = config->pan_domains_trusted; domain_trusted != NULL; domain_trusted = domain_trusted->next) {
 		has_content = 1;
-		fprintf(fd_ipset, "ipset=/.%s/%s\n", domain_trusted->domain, CHAIN_IPSET_TDOMAIN);	
+		fprintf(fd_ipset, "ipset=/.%s/%s\n", domain_trusted->domain, CHAIN_IPSET_TDOMAIN);
 	}
 
 	UNLOCK_DOMAIN();
 
 	fclose(fd_ipset);
-	
+
 	if(!has_content)
 		remove(f_ipset_name);
 
 	iptables_flush_ipset(CHAIN_IPSET_TDOMAIN);
-	execute("/etc/init.d/dnsmasq restart", 1);		
+	execute("/etc/init.d/dnsmasq restart", 1);
 }
 
 void
@@ -486,10 +496,10 @@ iptables_fw_set_inner_domains_trusted(void)
 	const s_config *config;
 	t_domain_trusted *domain_trusted = NULL;
 
-    config = config_get_config();
-	
+	config = config_get_config();
+
 	LOCK_DOMAIN();
-	
+
 	for (domain_trusted = config->inner_domains_trusted; domain_trusted != NULL; domain_trusted = domain_trusted->next) {
 		t_ip_trusted *ip_trusted = NULL;
 		for(ip_trusted = domain_trusted->ips_trusted; ip_trusted != NULL; ip_trusted = ip_trusted->next) {
@@ -524,9 +534,9 @@ iptables_fw_set_trusted_maclist(void)
 {
 	const s_config *config;
 	t_trusted_mac *p = NULL;
-	
-    config = config_get_config();
-	
+
+	config = config_get_config();
+
 	LOCK_CONFIG();
 	for (p = config->trustedmaclist; p != NULL; p = p->next)
 		ipset_do_command("add " CHAIN_TRUSTED " %s", p->mac);
@@ -551,7 +561,7 @@ iptables_fw_set_untrusted_maclist(void)
 	const s_config *config;
 	t_trusted_mac *p = NULL;
 
-    config = config_get_config();
+	config = config_get_config();
 
 	LOCK_CONFIG();
 	for (p = config->mac_blacklist; p != NULL; p = p->next)
@@ -564,9 +574,9 @@ void
 iptables_fw_set_mac_temporary(const char *mac, int which)
 {
 	if(which == 0) { // trusted
-		ipset_do_command("add " CHAIN_TRUSTED " %s timeout 60 ", mac);	
+		ipset_do_command("add " CHAIN_TRUSTED " %s timeout 60 ", mac);
 	} else if(which == 1) { // untrusted
-		ipset_do_command("add " CHAIN_UNTRUSTED " %s timeout 60 ", mac);	
+		ipset_do_command("add " CHAIN_UNTRUSTED " %s timeout 60 ", mac);
 	}
 }
 
@@ -585,7 +595,7 @@ f_fw_init_open()
 {
 	if(f_fw_init)
 		return;
-	
+
 	f_fw_init = fopen(fw_init_script, "w"); 
 	if(f_fw_init) {
 		fprintf(f_fw_init, "#!/bin/sh\n");
@@ -659,23 +669,23 @@ iptables_fw_save_online_clients()
 
 	LOCK_CLIENT_LIST();
 
-    client_list_dup(&sublist);
+	client_list_dup(&sublist);
 
-    UNLOCK_CLIENT_LIST();
+	UNLOCK_CLIENT_LIST();
 
-    current = sublist;
-	
+	current = sublist;
+
 	f_fw_allow_open();
 
-    while (current != NULL) {
+	while (current != NULL) {
 		iptables_do_command_save("-t mangle -A " CHAIN_OUTGOING " -s %s -m mac --mac-source %s -j MARK --set-mark %d", 
 					current->ip, current->mac, FW_MARK_KNOWN);
-        iptables_do_command_save("-t mangle -A " CHAIN_INCOMING " -d %s -j ACCEPT", current->ip);
+		iptables_do_command_save("-t mangle -A " CHAIN_INCOMING " -d %s -j ACCEPT", current->ip);
 
-        current = current->next;
-    }
+		current = current->next;
+	}
 
-	f_fw_allow_close();	
+	f_fw_allow_close();
 }
 // <<< liudf added end
 
@@ -684,41 +694,41 @@ iptables_fw_save_online_clients()
 int
 iptables_fw_init(void)
 {
-    const s_config *config;
-    char *ext_interface = NULL;
-    int gw_port = 0;
+	const s_config *config;
+	char *ext_interface = NULL;
+	int gw_port = 0;
 	int gw_https_port = 0;
 	int gw_http_port = 0;
-    int proxy_port;
-    fw_quiet = 0;
-    int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
-	
-	// liudf added 20160127	
+	int proxy_port;
+	fw_quiet = 0;
+	int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
+
+	struct fw3_ipt_handle *handle;
+
+	// liudf added 20160127
 	if(access(fw_init_script, F_OK|X_OK)) {
 		// need to create it
 		f_fw_init_open();
 	} else {
 		// execut fw_init_script
 	}
-	
-    config = config_get_config();
-    gw_port = config->gw_port;
+
+	config = config_get_config();
+	gw_port = config->gw_port;
 	gw_https_port = config->https_server->gw_https_port;
 	gw_http_port = config->http_server->gw_http_port;
-	
-    if (config->external_interface) {
-        ext_interface = safe_strdup(config->external_interface);
-    } else {
-        ext_interface = get_ext_iface();
-    }
 
-    if (ext_interface == NULL) {
-		f_fw_init_close();	
-        debug(LOG_ERR, "FATAL: no external interface");
-        return 0;
-    }
-	
-	
+	if (config->external_interface) {
+		ext_interface = safe_strdup(config->external_interface);
+	} else {
+		ext_interface = get_ext_iface();
+	}
+
+	if (ext_interface == NULL) {
+		f_fw_init_close();
+		debug(LOG_ERR, "FATAL: no external interface");
+		return 0;
+	}
 
 	// add ipset support
 	ipset_do_command("create " CHAIN_TRUSTED " hash:mac timeout 0 ");
@@ -728,190 +738,202 @@ iptables_fw_init(void)
 	ipset_do_command("create " CHAIN_INNER_DOMAIN_TRUSTED " hash:ip ");
 	ipset_do_command("create " CHAIN_IPSET_TDOMAIN " hash:ip ");
 
-    /*
-     *
-     * Everything in the MANGLE table
-     *
-     */
 
-    /* Create new chains */
-	// liudf added 20160106
-    iptables_do_command("-t mangle -N " CHAIN_ROAM);
-    iptables_do_command("-t mangle -N " CHAIN_TRUSTED);
-    iptables_do_command("-t mangle -N " CHAIN_OUTGOING);
-    iptables_do_command("-t mangle -N " CHAIN_INCOMING);
-	iptables_do_command("-t mangle -N " CHAIN_TO_PASS);
-    if (got_authdown_ruleset)
-        iptables_do_command("-t mangle -N " CHAIN_AUTH_IS_DOWN);
+	/*
+	 *
+	 * Everything in the MANGLE table
+	 *
+	 */
 
-    /* Assign links and rules to these new chains */
-    iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_OUTGOING, config->gw_interface);
-    iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_TRUSTED, config->gw_interface);     //this rule will be inserted before the prior one
+	handle = fw3_ipt_open(FW3_TABLE_MANGLE);
+
+	/* Create new chains */
 	// liudf added 20160106
-	iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_TO_PASS, config->gw_interface);
+	iptables_do_append_command(handle, "-t mangle -N " CHAIN_ROAM);
+	iptables_do_append_command(handle, "-t mangle -N " CHAIN_TRUSTED);
+	iptables_do_append_command(handle, "-t mangle -N " CHAIN_OUTGOING);
+	iptables_do_append_command(handle, "-t mangle -N " CHAIN_INCOMING);
+	iptables_do_append_command(handle, "-t mangle -N " CHAIN_TO_PASS);
+	if (got_authdown_ruleset)
+		iptables_do_append_command(handle, "-t mangle -N " CHAIN_AUTH_IS_DOWN);
+	/* Assign links and rules to these new chains */
+	iptables_do_append_command(handle, "-t mangle -I PREROUTING 1 -i %s -j " CHAIN_OUTGOING, config->gw_interface);
+	iptables_do_append_command(handle, "-t mangle -I PREROUTING 1 -i %s -j " CHAIN_TRUSTED, config->gw_interface);
+	// liudf added 20160106
+	iptables_do_append_command(handle, "-t mangle -I PREROUTING 1 -i %s -j " CHAIN_TO_PASS, config->gw_interface);
+
 	if( config->no_auth != 0 ) {
-    	debug(LOG_DEBUG, "No auth set");
-		iptables_do_command("-t mangle -A " CHAIN_TO_PASS " -j MARK --set-mark %d", FW_MARK_KNOWN);
+		debug(LOG_DEBUG, "No auth set");
+		iptables_do_append_command(handle, "-t mangle -A " CHAIN_TO_PASS " -j MARK --set-mark %d", FW_MARK_KNOWN);
 	}
-    iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_ROAM, config->gw_interface);    
-	iptables_do_command("-t mangle -A " CHAIN_ROAM " -m set --match-set " CHAIN_ROAM " src -j MARK --set-mark %d",
-		 				FW_MARK_KNOWN);
 
-    if (got_authdown_ruleset)
-        iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_AUTH_IS_DOWN, config->gw_interface);    //this rule must be last in the chain
-    iptables_do_command("-t mangle -I POSTROUTING 1 -o %s -j " CHAIN_INCOMING, config->gw_interface);
-	
-	//>>> liudf added&modified 20160113	 
-    iptables_do_command("-t mangle -A " CHAIN_TRUSTED " -m set --match-set " CHAIN_TRUSTED " src -j MARK --set-mark %d",
-		 				FW_MARK_KNOWN);
+	iptables_do_append_command(handle, "-t mangle -I PREROUTING 1 -i %s -j " CHAIN_ROAM, config->gw_interface);
+	iptables_do_append_command(handle, "-t mangle -A " CHAIN_ROAM " -m set --match-set " CHAIN_ROAM " src -j MARK --set-mark %d", FW_MARK_KNOWN);
+
+	if (got_authdown_ruleset)
+		iptables_do_append_command(handle, "-t mangle -I PREROUTING 1 -i %s -j " CHAIN_AUTH_IS_DOWN, config->gw_interface);
+
+	iptables_do_append_command(handle, "-t mangle -I POSTROUTING 1 -o %s -j " CHAIN_INCOMING, config->gw_interface);
+	//>>> liudf added&modified 20160113
+	iptables_do_append_command(handle, "-t mangle -A " CHAIN_TRUSTED " -m set --match-set " CHAIN_TRUSTED " src -j MARK --set-mark %d", FW_MARK_KNOWN);
 	//<<< liudf added end
 
-    /*
-     *
-     * Everything in the NAT table
-     *
-     */
+	fw3_ipt_commit(handle);
+	fw3_ipt_close(handle);
 
-    /* Create new chains */
- 	iptables_do_command("-t nat -N " CHAIN_UNTRUSTED);
-    iptables_do_command("-t nat -N " CHAIN_OUTGOING);
-    iptables_do_command("-t nat -N " CHAIN_TO_ROUTER);
-    iptables_do_command("-t nat -N " CHAIN_TO_INTERNET);
-    iptables_do_command("-t nat -N " CHAIN_GLOBAL);
-    iptables_do_command("-t nat -N " CHAIN_UNKNOWN);
-    iptables_do_command("-t nat -N " CHAIN_AUTHSERVERS);
+
+	/*
+	 *
+	 * Everything in the NAT table
+	 *
+	 */
+
+	handle = fw3_ipt_open(FW3_TABLE_NAT);
+
+	/* Create new chains */
+	iptables_do_append_command(handle, "-t nat -N " CHAIN_UNTRUSTED);
+	iptables_do_append_command(handle, "-t nat -N " CHAIN_OUTGOING);
+	iptables_do_append_command(handle, "-t nat -N " CHAIN_TO_ROUTER);
+	iptables_do_append_command(handle, "-t nat -N " CHAIN_TO_INTERNET);
+	iptables_do_append_command(handle, "-t nat -N " CHAIN_GLOBAL);
+	iptables_do_append_command(handle, "-t nat -N " CHAIN_UNKNOWN);
+	iptables_do_append_command(handle, "-t nat -N " CHAIN_AUTHSERVERS);
 	//>>> liudf added 20151224
-    iptables_do_command("-t nat -N " CHAIN_DOMAIN_TRUSTED);
-    iptables_do_command("-t nat -N " CHAIN_TO_PASS);
-    //<<< liudf added end
+	iptables_do_append_command(handle, "-t nat -N " CHAIN_DOMAIN_TRUSTED);
+	iptables_do_append_command(handle, "-t nat -N " CHAIN_TO_PASS);
+	//<<< liudf added end
 	if (got_authdown_ruleset)
-        iptables_do_command("-t nat -N " CHAIN_AUTH_IS_DOWN);
-	
+		iptables_do_append_command(handle, "-t nat -N " CHAIN_AUTH_IS_DOWN);
+
 	//>>> liudf added 20160113
 	// add this rule for mac blacklist
- 	iptables_do_command("-t nat -A PREROUTING -i %s -j " CHAIN_UNTRUSTED, config->gw_interface);
-	iptables_do_command("-t nat -A " CHAIN_UNTRUSTED " -p tcp -m set --match-set " CHAIN_UNTRUSTED " src -j REDIRECT --to-ports 44444");
-	iptables_do_command("-t nat -A " CHAIN_UNTRUSTED " -p udp -m set --match-set " CHAIN_UNTRUSTED " src -j REDIRECT --to-ports 44444");
+	iptables_do_append_command(handle, "-t nat -A PREROUTING -i %s -j " CHAIN_UNTRUSTED, config->gw_interface);
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_UNTRUSTED " -p tcp -m set --match-set " CHAIN_UNTRUSTED " src -j REDIRECT --to-ports 44444");
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_UNTRUSTED " -p udp -m set --match-set " CHAIN_UNTRUSTED " src -j REDIRECT --to-ports 44444");
 	//<<<
 
-    /* Assign links and rules to these new chains */
-    iptables_do_command("-t nat -A PREROUTING -i %s -j " CHAIN_OUTGOING, config->gw_interface);
-	
-	
-    iptables_do_command("-t nat -A " CHAIN_OUTGOING " -d %s -j " CHAIN_TO_ROUTER, config->gw_address);
-    iptables_do_command("-t nat -A " CHAIN_TO_ROUTER " -j ACCEPT");
+	/* Assign links and rules to these new chains */
+	iptables_do_append_command(handle, "-t nat -A PREROUTING -i %s -j " CHAIN_OUTGOING, config->gw_interface);
 
-    iptables_do_command("-t nat -A " CHAIN_OUTGOING " -j " CHAIN_TO_INTERNET);
-	iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -j " CHAIN_TO_PASS);
-	
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_OUTGOING " -d %s -j " CHAIN_TO_ROUTER, config->gw_address);
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_TO_ROUTER " -j ACCEPT");
+
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_OUTGOING " -j " CHAIN_TO_INTERNET);
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_TO_INTERNET " -j " CHAIN_TO_PASS);
+
 	if ((proxy_port = config_get_config()->proxy_port) != 0) {
-        debug(LOG_DEBUG, "Proxy port set, setting proxy rule");
-        iptables_do_command("-t nat -A " CHAIN_TO_PASS
-                            " -p tcp --dport 80 -m mark --mark 0x%u -j REDIRECT --to-port %u", FW_MARK_KNOWN,
-                            proxy_port);
-        iptables_do_command("-t nat -A " CHAIN_TO_PASS
-                            " -p tcp --dport 80 -m mark --mark 0x%u -j REDIRECT --to-port %u", FW_MARK_PROBATION,
-                            proxy_port);
-    }
+		debug(LOG_DEBUG, "Proxy port set, setting proxy rule");
 
-    iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j ACCEPT", FW_MARK_KNOWN);
-    iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j ACCEPT", FW_MARK_PROBATION);
-    iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -j " CHAIN_UNKNOWN);
-
-    iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_AUTHSERVERS);
-	// liudf added 20151224
-    iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_DOMAIN_TRUSTED);
-	iptables_do_command("-t nat -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_IPSET_TDOMAIN " dst -j ACCEPT");
-	iptables_do_command("-t nat -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_DOMAIN_TRUSTED " dst -j ACCEPT");
-	iptables_do_command("-t nat -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_INNER_DOMAIN_TRUSTED " dst -j ACCEPT");
-    iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_GLOBAL);
-    if (got_authdown_ruleset) {
-        iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_AUTH_IS_DOWN);
-        iptables_do_command("-t nat -A " CHAIN_AUTH_IS_DOWN " -m mark --mark 0x%u -j ACCEPT", FW_MARK_AUTH_IS_DOWN);
-    }
-	
-	if (config_get_config()->work_mode == 0) {
-		iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -p tcp --dport 443 -j REDIRECT --to-ports %d", gw_https_port);
-    	iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -p tcp --dport 80 -j REDIRECT --to-ports %d", gw_port);
-	} else {
-		iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -p tcp --dport 80 -j REDIRECT --to-ports %d", gw_http_port);
+		iptables_do_append_command(handle, "-t nat -A " CHAIN_TO_PASS
+							" -p tcp --dport 80 -m mark --mark 0x%u -j REDIRECT --to-port %u", FW_MARK_KNOWN,
+							proxy_port);
+		iptables_do_append_command(handle, "-t nat -A " CHAIN_TO_PASS
+							" -p tcp --dport 80 -m mark --mark 0x%u -j REDIRECT --to-port %u", FW_MARK_PROBATION,
+							proxy_port);
 	}
-    /*
-     *
-     * Everything in the FILTER table
-     *
-     */
 
-    /* Create new chains */
-    iptables_do_command("-t filter -N " CHAIN_TO_INTERNET);
-    iptables_do_command("-t filter -N " CHAIN_AUTHSERVERS);
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j ACCEPT", FW_MARK_KNOWN);
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j ACCEPT", FW_MARK_PROBATION);
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_TO_INTERNET " -j " CHAIN_UNKNOWN);
+
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_AUTHSERVERS);
+	iptables_fw_set_authservers(handle);
+
 	// liudf added 20151224
-    iptables_do_command("-t filter -N " CHAIN_DOMAIN_TRUSTED);
-    iptables_do_command("-t filter -N " CHAIN_LOCKED);
-    iptables_do_command("-t filter -N " CHAIN_GLOBAL);
-    iptables_do_command("-t filter -N " CHAIN_VALIDATE);
-    iptables_do_command("-t filter -N " CHAIN_KNOWN);
-    iptables_do_command("-t filter -N " CHAIN_UNKNOWN);
-    if (got_authdown_ruleset)
-        iptables_do_command("-t filter -N " CHAIN_AUTH_IS_DOWN);
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_DOMAIN_TRUSTED);
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_IPSET_TDOMAIN " dst -j ACCEPT");
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_DOMAIN_TRUSTED " dst -j ACCEPT");
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_INNER_DOMAIN_TRUSTED " dst -j ACCEPT");
+	iptables_do_append_command(handle, "-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_GLOBAL);
+	iptables_load_ruleset("nat", FWRULESET_GLOBAL, CHAIN_GLOBAL, handle);
 
-    /* Assign links and rules to these new chains */
-	
-    /* Insert at the beginning */
-    iptables_do_command("-t filter -I FORWARD -i %s -j " CHAIN_TO_INTERNET, config->gw_interface);
+	if (got_authdown_ruleset) {
+		iptables_do_append_command(handle, "-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_AUTH_IS_DOWN);
+		iptables_do_append_command(handle, "-t nat -A " CHAIN_AUTH_IS_DOWN " -m mark --mark 0x%u -j ACCEPT", FW_MARK_AUTH_IS_DOWN);
+	}
 
-    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m state --state INVALID -j DROP");
+	if (config_get_config()->work_mode == 0) {
+		iptables_do_append_command(handle, "-t nat -A " CHAIN_UNKNOWN " -p tcp --dport 443 -j REDIRECT --to-ports %d", gw_https_port);
+		iptables_do_append_command(handle, "-t nat -A " CHAIN_UNKNOWN " -p tcp --dport 80 -j REDIRECT --to-ports %d", gw_port);
+	} else {
+		iptables_do_append_command(handle, "-t nat -A " CHAIN_UNKNOWN " -p tcp --dport 80 -j REDIRECT --to-ports %d", gw_http_port);
+	}
 
-    /* XXX: Why this? it means that connections setup after authentication
-       stay open even after the connection is done... 
-       iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m state --state RELATED,ESTABLISHED -j ACCEPT"); */
+	fw3_ipt_commit(handle);
+	fw3_ipt_close(handle);
 
-    //Won't this rule NEVER match anyway?!?!? benoitg, 2007-06-23
-    //iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -i %s -m state --state NEW -j DROP", ext_interface);
 
-    /* TCPMSS rule for PPPoE */
-    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET
-                        " -o %s -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu", ext_interface);
-	
+	/*
+	 *
+	 * Everything in the FILTER table
+	 *
+	 */
+
+	/* Create new chains */
+	handle = fw3_ipt_open(FW3_TABLE_FILTER);
+
+	iptables_do_append_command(handle, "-t filter -N " CHAIN_TO_INTERNET);
+	iptables_do_append_command(handle, "-t filter -N " CHAIN_AUTHSERVERS);
 	// liudf added 20151224
-    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_LOCKED, FW_MARK_LOCKED);
-    iptables_load_ruleset("filter", FWRULESET_LOCKED_USERS, CHAIN_LOCKED);
+	iptables_do_append_command(handle, "-t filter -N " CHAIN_DOMAIN_TRUSTED);
+	iptables_do_append_command(handle, "-t filter -N " CHAIN_LOCKED);
+	iptables_do_append_command(handle, "-t filter -N " CHAIN_GLOBAL);
+	iptables_do_append_command(handle, "-t filter -N " CHAIN_VALIDATE);
+	iptables_do_append_command(handle, "-t filter -N " CHAIN_KNOWN);
+	iptables_do_append_command(handle, "-t filter -N " CHAIN_UNKNOWN);
+	if (got_authdown_ruleset)
+		iptables_do_append_command(handle, "-t filter -N " CHAIN_AUTH_IS_DOWN);
 
-    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_AUTHSERVERS);
-    iptables_fw_set_authservers();
-	    
-	iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_DOMAIN_TRUSTED);
-	iptables_do_command("-t filter -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_IPSET_TDOMAIN " dst -j ACCEPT");
-	iptables_do_command("-t filter -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_DOMAIN_TRUSTED " dst -j ACCEPT");
-	iptables_do_command("-t filter -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_INNER_DOMAIN_TRUSTED " dst -j ACCEPT");
-	
+	/* Insert at the beginning */
+	iptables_do_append_command(handle, "-t filter -I FORWARD -i %s -j " CHAIN_TO_INTERNET, config->gw_interface);
 
-    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_GLOBAL);
-  	iptables_load_ruleset("filter", FWRULESET_GLOBAL, CHAIN_GLOBAL);
-    iptables_load_ruleset("nat", FWRULESET_GLOBAL, CHAIN_GLOBAL);
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -m state --state INVALID -j DROP");
 
-    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_VALIDATE, FW_MARK_PROBATION);
-    iptables_load_ruleset("filter", FWRULESET_VALIDATING_USERS, CHAIN_VALIDATE);
+	/* TCPMSS rule for PPPoE */
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET
+						" -o %s -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu", ext_interface);
 
-    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_KNOWN, FW_MARK_KNOWN);
-    iptables_load_ruleset("filter", FWRULESET_KNOWN_USERS, CHAIN_KNOWN);
+	// liudf added 20151224
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_LOCKED, FW_MARK_LOCKED);
+	iptables_load_ruleset("filter", FWRULESET_LOCKED_USERS, CHAIN_LOCKED, handle);
 
-    if (got_authdown_ruleset) {
-        iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_AUTH_IS_DOWN,
-                            FW_MARK_AUTH_IS_DOWN);
-        iptables_load_ruleset("filter", FWRULESET_AUTH_IS_DOWN, CHAIN_AUTH_IS_DOWN);
-    }
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_AUTHSERVERS);
+	iptables_fw_set_authservers(handle);
 
-    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_UNKNOWN);
-    iptables_load_ruleset("filter", FWRULESET_UNKNOWN_USERS, CHAIN_UNKNOWN);
-    iptables_do_command("-t filter -A " CHAIN_UNKNOWN " -j REJECT --reject-with icmp-port-unreachable");
-	
-    free(ext_interface);
-	
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_DOMAIN_TRUSTED);
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_IPSET_TDOMAIN " dst -j ACCEPT");
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_DOMAIN_TRUSTED " dst -j ACCEPT");
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_DOMAIN_TRUSTED " -m set --match-set " CHAIN_INNER_DOMAIN_TRUSTED " dst -j ACCEPT");
+
+
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_GLOBAL);
+	iptables_load_ruleset("filter", FWRULESET_GLOBAL, CHAIN_GLOBAL, handle);
+
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_VALIDATE, FW_MARK_PROBATION);
+	iptables_load_ruleset("filter", FWRULESET_VALIDATING_USERS, CHAIN_VALIDATE, handle);
+
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_KNOWN, FW_MARK_KNOWN);
+	iptables_load_ruleset("filter", FWRULESET_KNOWN_USERS, CHAIN_KNOWN, handle);
+
+	if (got_authdown_ruleset) {
+		iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_AUTH_IS_DOWN,
+							FW_MARK_AUTH_IS_DOWN);
+		iptables_load_ruleset("filter", FWRULESET_AUTH_IS_DOWN, CHAIN_AUTH_IS_DOWN, handle);
+	}
+
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_UNKNOWN);
+	iptables_load_ruleset("filter", FWRULESET_UNKNOWN_USERS, CHAIN_UNKNOWN, handle);
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_UNKNOWN " -j REJECT --reject-with icmp-port-unreachable");
+
+	fw3_ipt_commit(handle);
+	fw3_ipt_close(handle);
+
+	free(ext_interface);
+
 	f_fw_init_close();
 	//<<< liudf added end
 
-    return 1;
+	return 1;
 }
 
 /** Remove the firewall rules
@@ -921,123 +943,125 @@ iptables_fw_init(void)
 int
 iptables_fw_destroy(void)
 {
-    int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
-    fw_quiet = 1;
+	int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
+	fw_quiet = 1;
 
-    debug(LOG_DEBUG, "Destroying our iptables entries");
-	
-	// liudf added 20160127	
+	debug(LOG_DEBUG, "Destroying our iptables entries");
+
+	// liudf added 20160127
 	if(access(fw_destroy_script, F_OK|X_OK)) {
 		f_fw_destroy_open();
 	} else {
 	}
 	
-    /*
-     *
-     * Everything in the MANGLE table
-     *
-     */
-    debug(LOG_DEBUG, "Destroying chains in the MANGLE table");
+	/*
+	 *
+	 * Everything in the MANGLE table
+	 *
+	 */
+	debug(LOG_DEBUG, "Destroying chains in the MANGLE table");
 	// liudf added 20160106
-    iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_TO_PASS);
-    iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_ROAM);
-    iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_TRUSTED);
-    iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_OUTGOING);
-    if (got_authdown_ruleset)
-        iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_AUTH_IS_DOWN);
-    iptables_fw_destroy_mention("mangle", "POSTROUTING", CHAIN_INCOMING);
+	iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_TO_PASS, NULL);
+	iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_ROAM, NULL);
+	iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_TRUSTED, NULL);
+	iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_OUTGOING, NULL);
+	if (got_authdown_ruleset)
+		iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_AUTH_IS_DOWN, NULL);
+	iptables_fw_destroy_mention("mangle", "POSTROUTING", CHAIN_INCOMING, NULL);
 	// liudf added 20160106
 	iptables_do_command("-t mangle -F " CHAIN_TO_PASS);
-    iptables_do_command("-t mangle -F " CHAIN_ROAM);
-    iptables_do_command("-t mangle -F " CHAIN_TRUSTED);
-    iptables_do_command("-t mangle -F " CHAIN_OUTGOING);
-    if (got_authdown_ruleset)
-        iptables_do_command("-t mangle -F " CHAIN_AUTH_IS_DOWN);
-    iptables_do_command("-t mangle -F " CHAIN_INCOMING);
+	iptables_do_command("-t mangle -F " CHAIN_ROAM);
+	iptables_do_command("-t mangle -F " CHAIN_TRUSTED);
+	iptables_do_command("-t mangle -F " CHAIN_OUTGOING);
+	if (got_authdown_ruleset)
+		iptables_do_command("-t mangle -F " CHAIN_AUTH_IS_DOWN);
+	iptables_do_command("-t mangle -F " CHAIN_INCOMING);
 	// liudf added 20160106
 	iptables_do_command("-t mangle -X " CHAIN_TO_PASS);
-    iptables_do_command("-t mangle -X " CHAIN_ROAM);
-    iptables_do_command("-t mangle -X " CHAIN_TRUSTED);
-    iptables_do_command("-t mangle -X " CHAIN_OUTGOING);
-    if (got_authdown_ruleset)
-        iptables_do_command("-t mangle -X " CHAIN_AUTH_IS_DOWN);
-    iptables_do_command("-t mangle -X " CHAIN_INCOMING);
+	iptables_do_command("-t mangle -X " CHAIN_ROAM);
+	iptables_do_command("-t mangle -X " CHAIN_TRUSTED);
+	iptables_do_command("-t mangle -X " CHAIN_OUTGOING);
+	if (got_authdown_ruleset)
+		iptables_do_command("-t mangle -X " CHAIN_AUTH_IS_DOWN);
+	iptables_do_command("-t mangle -X " CHAIN_INCOMING);
 
-    /*
-     *
-     * Everything in the NAT table
-     *
-     */
-    debug(LOG_DEBUG, "Destroying chains in the NAT table");
-    iptables_fw_destroy_mention("nat", "PREROUTING", CHAIN_UNTRUSTED);
-    iptables_fw_destroy_mention("nat", "PREROUTING", CHAIN_OUTGOING);
-    iptables_do_command("-t nat -F " CHAIN_AUTHSERVERS);
+	/*
+	 *
+	 * Everything in the NAT table
+	 *
+	 */
+	debug(LOG_DEBUG, "Destroying chains in the NAT table");
+	iptables_fw_destroy_mention("nat", "PREROUTING", CHAIN_UNTRUSTED, NULL);
+	iptables_fw_destroy_mention("nat", "PREROUTING", CHAIN_OUTGOING, NULL);
+	iptables_do_command("-t nat -F " CHAIN_AUTHSERVERS);
 	// liudf added 20151224
 	iptables_do_command("-t nat -F " CHAIN_TO_PASS);
-    iptables_do_command("-t nat -F " CHAIN_UNTRUSTED);
-    iptables_do_command("-t nat -F " CHAIN_DOMAIN_TRUSTED);
-    iptables_do_command("-t nat -F " CHAIN_OUTGOING);
-    if (got_authdown_ruleset)
-        iptables_do_command("-t nat -F " CHAIN_AUTH_IS_DOWN);
-    iptables_do_command("-t nat -F " CHAIN_TO_ROUTER);
-    iptables_do_command("-t nat -F " CHAIN_TO_INTERNET);
-    iptables_do_command("-t nat -F " CHAIN_GLOBAL);
-    iptables_do_command("-t nat -F " CHAIN_UNKNOWN);
-    iptables_do_command("-t nat -X " CHAIN_AUTHSERVERS);
+	iptables_do_command("-t nat -F " CHAIN_UNTRUSTED);
+	iptables_do_command("-t nat -F " CHAIN_DOMAIN_TRUSTED);
+	iptables_do_command("-t nat -F " CHAIN_OUTGOING);
+	if (got_authdown_ruleset)
+		iptables_do_command("-t nat -F " CHAIN_AUTH_IS_DOWN);
+	iptables_do_command("-t nat -F " CHAIN_TO_ROUTER);
+	iptables_do_command("-t nat -F " CHAIN_TO_INTERNET);
+	iptables_do_command("-t nat -F " CHAIN_GLOBAL);
+	iptables_do_command("-t nat -F " CHAIN_UNKNOWN);
+	iptables_do_command("-t nat -X " CHAIN_AUTHSERVERS);
 	iptables_do_command("-t nat -X " CHAIN_TO_PASS);
 	// liudf added 20151224
    	iptables_do_command("-t nat -X " CHAIN_UNTRUSTED);
-    iptables_do_command("-t nat -X " CHAIN_DOMAIN_TRUSTED);
-    iptables_do_command("-t nat -X " CHAIN_OUTGOING);
-    if (got_authdown_ruleset)
-        iptables_do_command("-t nat -X " CHAIN_AUTH_IS_DOWN);
-    iptables_do_command("-t nat -X " CHAIN_TO_ROUTER);
-    iptables_do_command("-t nat -X " CHAIN_TO_INTERNET);
-    iptables_do_command("-t nat -X " CHAIN_GLOBAL);
-    iptables_do_command("-t nat -X " CHAIN_UNKNOWN);
+	iptables_do_command("-t nat -X " CHAIN_DOMAIN_TRUSTED);
+	iptables_do_command("-t nat -X " CHAIN_OUTGOING);
+	if (got_authdown_ruleset)
+		iptables_do_command("-t nat -X " CHAIN_AUTH_IS_DOWN);
+	iptables_do_command("-t nat -X " CHAIN_TO_ROUTER);
+	iptables_do_command("-t nat -X " CHAIN_TO_INTERNET);
+	iptables_do_command("-t nat -X " CHAIN_GLOBAL);
+	iptables_do_command("-t nat -X " CHAIN_UNKNOWN);
 
-    /*
-     *
-     * Everything in the FILTER table
-     *
-     */
-    debug(LOG_DEBUG, "Destroying chains in the FILTER table");
-    iptables_fw_destroy_mention("filter", "FORWARD", CHAIN_TO_INTERNET);
-    iptables_do_command("-t filter -F " CHAIN_TO_INTERNET);
-    iptables_do_command("-t filter -F " CHAIN_AUTHSERVERS);
+	/*
+	 *
+	 * Everything in the FILTER table
+	 *
+	 */
+	debug(LOG_DEBUG, "Destroying chains in the FILTER table");
+	iptables_fw_destroy_mention("filter", "FORWARD", CHAIN_TO_INTERNET, NULL);
+	iptables_do_command("-t filter -F " CHAIN_TO_INTERNET);
+	iptables_do_command("-t filter -F " CHAIN_AUTHSERVERS);
 	// liudf added 20151224
-    iptables_do_command("-t filter -F " CHAIN_DOMAIN_TRUSTED);
-    iptables_do_command("-t filter -F " CHAIN_LOCKED);
-    iptables_do_command("-t filter -F " CHAIN_GLOBAL);
-    iptables_do_command("-t filter -F " CHAIN_VALIDATE);
-    iptables_do_command("-t filter -F " CHAIN_KNOWN);
-    iptables_do_command("-t filter -F " CHAIN_UNKNOWN);
-    if (got_authdown_ruleset)
-        iptables_do_command("-t filter -F " CHAIN_AUTH_IS_DOWN);
-    iptables_do_command("-t filter -X " CHAIN_TO_INTERNET);
-    iptables_do_command("-t filter -X " CHAIN_AUTHSERVERS);
+	iptables_do_command("-t filter -F " CHAIN_DOMAIN_TRUSTED);
+	iptables_do_command("-t filter -F " CHAIN_LOCKED);
+	iptables_do_command("-t filter -F " CHAIN_GLOBAL);
+	iptables_do_command("-t filter -F " CHAIN_VALIDATE);
+	iptables_do_command("-t filter -F " CHAIN_KNOWN);
+	iptables_do_command("-t filter -F " CHAIN_UNKNOWN);
+	if (got_authdown_ruleset)
+		iptables_do_command("-t filter -F " CHAIN_AUTH_IS_DOWN);
+	iptables_do_command("-t filter -X " CHAIN_TO_INTERNET);
+	iptables_do_command("-t filter -X " CHAIN_AUTHSERVERS);
 	// liudf added 20151224
-    iptables_do_command("-t filter -X " CHAIN_DOMAIN_TRUSTED);
-    iptables_do_command("-t filter -X " CHAIN_LOCKED);
-    iptables_do_command("-t filter -X " CHAIN_GLOBAL);
-    iptables_do_command("-t filter -X " CHAIN_VALIDATE);
-    iptables_do_command("-t filter -X " CHAIN_KNOWN);
-    iptables_do_command("-t filter -X " CHAIN_UNKNOWN);
-    if (got_authdown_ruleset)
-        iptables_do_command("-t filter -X " CHAIN_AUTH_IS_DOWN);
+	iptables_do_command("-t filter -X " CHAIN_DOMAIN_TRUSTED);
+	iptables_do_command("-t filter -X " CHAIN_LOCKED);
+	iptables_do_command("-t filter -X " CHAIN_GLOBAL);
+	iptables_do_command("-t filter -X " CHAIN_VALIDATE);
+	iptables_do_command("-t filter -X " CHAIN_KNOWN);
+	iptables_do_command("-t filter -X " CHAIN_UNKNOWN);
+	if (got_authdown_ruleset)
+		iptables_do_command("-t filter -X " CHAIN_AUTH_IS_DOWN);
+
+	//>>> destroy all our ipset set
+	debug(LOG_DEBUG, "Destroying our ipset entries");
 	
-	//>>> destroy all our ipset set 	
 	ipset_do_command("destroy " CHAIN_TRUSTED);
 	ipset_do_command("destroy " CHAIN_ROAM);
 	ipset_do_command("destroy " CHAIN_UNTRUSTED);
 	ipset_do_command("destroy " CHAIN_DOMAIN_TRUSTED);
 	ipset_do_command("destroy " CHAIN_INNER_DOMAIN_TRUSTED);
 	ipset_do_command("destroy " CHAIN_IPSET_TDOMAIN);
-	
+
 	// liudf added 20160127
 	f_fw_destroy_close();
 
-    return 1;
+	return 1;
 }
 
 /*
@@ -1047,131 +1071,134 @@ iptables_fw_destroy(void)
  * @param mention A word to find and delete in rules in the given table+chain
  */
 int
-iptables_fw_destroy_mention(const char *table, const char *chain, const char *mention)
+iptables_fw_destroy_mention(const char *table, const char *chain, const char *mention, void *handle)
 {
-    FILE *p = NULL;
-    char *command = NULL;
-    char *command2 = NULL;
-    char line[MAX_BUF] = {0};
-    char rulenum[10] = {0};
-    char *victim = safe_strdup(mention);
-    int deleted = 0;
+	FILE *p = NULL;
+	char *command = NULL;
+	char *command2 = NULL;
+	char line[MAX_BUF] = {0};
+	char rulenum[10] = {0};
+	char *victim = safe_strdup(mention);
+	int deleted = 0;
 
-    iptables_insert_gateway_id(&victim);
+	iptables_insert_gateway_id(&victim);
 
-    debug(LOG_DEBUG, "Attempting to destroy all mention of %s from %s.%s", victim, table, chain);
+	debug(LOG_DEBUG, "Attempting to destroy all mention of %s from %s.%s", victim, table, chain);
 
-    safe_asprintf(&command, "iptables -t %s -L %s -n --line-numbers -v", table, chain);
-    iptables_insert_gateway_id(&command);
+	safe_asprintf(&command, "iptables -t %s -L %s -n --line-numbers -v", table, chain);
+	iptables_insert_gateway_id(&command);
 
-    if ((p = popen(command, "r"))) {
-        /* Skip first 2 lines */
-        while (!feof(p) && fgetc(p) != '\n') ;
-        while (!feof(p) && fgetc(p) != '\n') ;
-        /* Loop over entries */
-        while (fgets(line, sizeof(line), p)) {
-            /* Look for victim */
-            if (strstr(line, victim)) {
-                /* Found victim - Get the rule number into rulenum */
-                if (sscanf(line, "%9[0-9]", rulenum) == 1) {
-                    /* Delete the rule: */
-                    debug(LOG_DEBUG, "Deleting rule %s from %s.%s because it mentions %s", rulenum, table, chain,
-                          victim);
-                    safe_asprintf(&command2, "-t %s -D %s %s", table, chain, rulenum);
-                    iptables_do_command(command2);
-                    free(command2);
-                    deleted = 1;
-                    /* Do not keep looping - the captured rulenums will no longer be accurate */
-                    break;
-                }
-            }
-        }
-        pclose(p);
-    }
+	if ((p = popen(command, "r"))) {
+		/* Skip first 2 lines */
+		while (!feof(p) && fgetc(p) != '\n') ;
+		while (!feof(p) && fgetc(p) != '\n') ;
+		/* Loop over entries */
+		while (fgets(line, sizeof(line), p)) {
+			/* Look for victim */
+			if (strstr(line, victim)) {
+				/* Found victim - Get the rule number into rulenum */
+				if (sscanf(line, "%9[0-9]", rulenum) == 1) {
+					/* Delete the rule: */
+					debug(LOG_DEBUG, "Deleting rule %s from %s.%s because it mentions %s", rulenum, table, chain,
+						  victim);
+					safe_asprintf(&command2, "-t %s -D %s %s", table, chain, rulenum);
+					if (handle)
+						iptables_do_append_command(handle, command2);
+					else
+						iptables_do_command(command2);
+					free(command2);
+					deleted = 1;
+					/* Do not keep looping - the captured rulenums will no longer be accurate */
+					break;
+				}
+			}
+		}
+		pclose(p);
+	}
 
-    free(command);
-    free(victim);
+	free(command);
+	free(victim);
 
-    if (deleted) {
-        /* Recurse just in case there are more in the same table+chain */
-        iptables_fw_destroy_mention(table, chain, mention);
-    }
+	if (deleted) {
+		/* Recurse just in case there are more in the same table+chain */
+		iptables_fw_destroy_mention(table, chain, mention, handle);
+	}
 
-    return (deleted);
+	return (deleted);
 }
 
 /** Set if a specific client has access through the firewall */
 int
 iptables_fw_access(fw_access_t type, const char *ip, const char *mac, int tag)
 {
-    int rc;
+	int rc;
 
-    fw_quiet = 0;
+	fw_quiet = 0;
 
-    switch (type) {
-    case FW_ACCESS_ALLOW:
-        iptables_do_command("-t mangle -A " CHAIN_OUTGOING " -s %s -m mac --mac-source %s -j MARK --set-mark %d", ip,
-                            mac, tag);
-        rc = iptables_do_command("-t mangle -A " CHAIN_INCOMING " -d %s -j ACCEPT", ip);
-        break;
-    case FW_ACCESS_DENY:
-        /* XXX Add looping to really clear? */
-        iptables_do_command("-t mangle -D " CHAIN_OUTGOING " -s %s -m mac --mac-source %s -j MARK --set-mark %d", ip,
-                            mac, tag);
-        rc = iptables_do_command("-t mangle -D " CHAIN_INCOMING " -d %s -j ACCEPT", ip);
-        break;
-    default:
-        rc = -1;
-        break;
-    }
+	switch (type) {
+	case FW_ACCESS_ALLOW:
+		iptables_do_command("-t mangle -A " CHAIN_OUTGOING " -s %s -m mac --mac-source %s -j MARK --set-mark %d", ip,
+							mac, tag);
+		rc = iptables_do_command("-t mangle -A " CHAIN_INCOMING " -d %s -j ACCEPT", ip);
+		break;
+	case FW_ACCESS_DENY:
+		/* XXX Add looping to really clear? */
+		iptables_do_command("-t mangle -D " CHAIN_OUTGOING " -s %s -m mac --mac-source %s -j MARK --set-mark %d", ip,
+							mac, tag);
+		rc = iptables_do_command("-t mangle -D " CHAIN_INCOMING " -d %s -j ACCEPT", ip);
+		break;
+	default:
+		rc = -1;
+		break;
+	}
 
-    return rc;
+	return rc;
 }
 
 int
 iptables_fw_access_host(fw_access_t type, const char *host)
 {
-    int rc;
+	int rc;
 
-    fw_quiet = 0;
+	fw_quiet = 0;
 
-    switch (type) {
-    case FW_ACCESS_ALLOW:
-        iptables_do_command("-t nat -A " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
-        rc = iptables_do_command("-t filter -A " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
-        break;
-    case FW_ACCESS_DENY:
-        iptables_do_command("-t nat -D " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
-        rc = iptables_do_command("-t filter -D " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
-        break;
-    default:
-        rc = -1;
-        break;
-    }
+	switch (type) {
+	case FW_ACCESS_ALLOW:
+		iptables_do_command("-t nat -A " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
+		rc = iptables_do_command("-t filter -A " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
+		break;
+	case FW_ACCESS_DENY:
+		iptables_do_command("-t nat -D " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
+		rc = iptables_do_command("-t filter -D " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
+		break;
+	default:
+		rc = -1;
+		break;
+	}
 
-    return rc;
+	return rc;
 }
 
 /** Set a mark when auth server is not reachable */
 int
 iptables_fw_auth_unreachable(int tag)
 {
-    int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
-    if (got_authdown_ruleset)
-        return iptables_do_command("-t mangle -A " CHAIN_AUTH_IS_DOWN " -j MARK --set-mark 0x%u", tag);
-    else
-        return 1;
+	int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
+	if (got_authdown_ruleset)
+		return iptables_do_command("-t mangle -A " CHAIN_AUTH_IS_DOWN " -j MARK --set-mark 0x%u", tag);
+	else
+		return 1;
 }
 
 /** Remove mark when auth server is reachable again */
 int
 iptables_fw_auth_reachable(void)
 {
-    int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
-    if (got_authdown_ruleset)
-        return iptables_do_command("-t mangle -F " CHAIN_AUTH_IS_DOWN);
-    else
-        return 1;
+	int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
+	if (got_authdown_ruleset)
+		return iptables_do_command("-t mangle -F " CHAIN_AUTH_IS_DOWN);
+	else
+		return 1;
 }
 
 // liudf added 20160127
@@ -1181,17 +1208,17 @@ __get_client_name(t_client *client)
 {
 	char cmd[256] = {0};
 	FILE *f_dhcp = NULL;
- 	
-	snprintf(cmd, 256, "cat /tmp/dhcp.leases |grep %s|cut -d' ' -f 4", client->ip);	
-	
-    debug(LOG_INFO, "__get_client_name [%s]", cmd);
+
+	snprintf(cmd, 256, "cat /tmp/dhcp.leases |grep %s|cut -d' ' -f 4", client->ip);
+
+	debug(LOG_INFO, "__get_client_name [%s]", cmd);
 	if((f_dhcp = popen(cmd, "r")) != NULL) {
 		char name[32] = {0};
 		fgets(name, 31,  f_dhcp);
 		pclose(f_dhcp);
 		trim_newline(name);
 		client->name = safe_strdup(name);
-    	debug(LOG_INFO, "__get_client_name [%s]", name);
+		debug(LOG_INFO, "__get_client_name [%s]", name);
 	}
 }
 
@@ -1199,120 +1226,120 @@ __get_client_name(t_client *client)
 int
 iptables_fw_counters_update(void)
 {
-    FILE *output;
-    char *script, ip[16] = {0}, rc;
-    unsigned long long int counter;
-    t_client *p1;
-    struct in_addr tempaddr;
+	FILE *output;
+	char *script, ip[16] = {0}, rc;
+	unsigned long long int counter;
+	t_client *p1;
+	struct in_addr tempaddr;
 
-    /* Look for outgoing traffic */
-    safe_asprintf(&script, "%s %s", "iptables", "-v -n -x -t mangle -L " CHAIN_OUTGOING);
-    iptables_insert_gateway_id(&script);
-    output = popen(script, "r");
-    free(script);
-    if (!output) {
-        debug(LOG_ERR, "popen(): %s", strerror(errno));
-        return -1;
-    }
-	
+	/* Look for outgoing traffic */
+	safe_asprintf(&script, "%s %s", "iptables", "-v -n -x -t mangle -L " CHAIN_OUTGOING);
+	iptables_insert_gateway_id(&script);
+	output = popen(script, "r");
+	free(script);
+	if (!output) {
+		debug(LOG_ERR, "popen(): %s", strerror(errno));
+		return -1;
+	}
+
 	// liudf added 20160216
 	LOCK_CLIENT_LIST();
 	reset_client_list();
 	UNLOCK_CLIENT_LIST();
 
-    /* skip the first two lines */
-    while (('\n' != fgetc(output)) && !feof(output)) ;
-    while (('\n' != fgetc(output)) && !feof(output)) ;
-    while (output && !(feof(output))) {
-        rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %15[0-9.] %*s %*s %*s %*s %*s %*s", &counter, ip);
-        //rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %15[0-9.] %*s %*s %*s %*s %*s 0x%*u", &counter, ip);
-        if (2 == rc && EOF != rc) {
-            /* Sanity */
-            if (!inet_aton(ip, &tempaddr)) {
-                debug(LOG_WARNING, "I was supposed to read an IP address but instead got [%s] - ignoring it", ip);
-                continue;
-            }
-            debug(LOG_DEBUG, "Read outgoing traffic for %s: Bytes=%llu", ip, counter);
-            LOCK_CLIENT_LIST();
-            if ((p1 = client_list_find_by_ip(ip))) {
-                if ((p1->counters.outgoing - p1->counters.outgoing_history) < counter) {
-                    p1->counters.outgoing_delta = p1->counters.outgoing_history + counter - p1->counters.outgoing;
-                    p1->counters.outgoing = p1->counters.outgoing_history + counter;
-                    p1->counters.last_updated = time(NULL);
-                    debug(LOG_DEBUG, "%s - Outgoing traffic %llu bytes, updated counter.outgoing to %llu bytes.  Updated last_updated to %d", ip,
-                          counter, p1->counters.outgoing, p1->counters.last_updated);
+	/* skip the first two lines */
+	while (('\n' != fgetc(output)) && !feof(output)) ;
+	while (('\n' != fgetc(output)) && !feof(output)) ;
+	while (output && !(feof(output))) {
+		rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %15[0-9.] %*s %*s %*s %*s %*s %*s", &counter, ip);
+		//rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %15[0-9.] %*s %*s %*s %*s %*s 0x%*u", &counter, ip);
+		if (2 == rc && EOF != rc) {
+			/* Sanity */
+			if (!inet_aton(ip, &tempaddr)) {
+				debug(LOG_WARNING, "I was supposed to read an IP address but instead got [%s] - ignoring it", ip);
+				continue;
+			}
+			debug(LOG_DEBUG, "Read outgoing traffic for %s: Bytes=%llu", ip, counter);
+			LOCK_CLIENT_LIST();
+			if ((p1 = client_list_find_by_ip(ip))) {
+				if ((p1->counters.outgoing - p1->counters.outgoing_history) < counter) {
+					p1->counters.outgoing_delta = p1->counters.outgoing_history + counter - p1->counters.outgoing;
+					p1->counters.outgoing = p1->counters.outgoing_history + counter;
+					p1->counters.last_updated = time(NULL);
+					debug(LOG_DEBUG, "%s - Outgoing traffic %llu bytes, updated counter.outgoing to %llu bytes.  Updated last_updated to %d", ip,
+						  counter, p1->counters.outgoing, p1->counters.last_updated);
 					p1->is_online = 1;
-                } 
-				
+				}
+
 				// liudf added 20160127
-				// get client name	
+				// get client name
 				if(p1->name == NULL)
 					__get_client_name(p1);
-				
+
 				if(p1->wired == -1) {
 					p1->wired = is_device_wired(p1->mac);
 				}
-            	UNLOCK_CLIENT_LIST();
-            } else {
-            	UNLOCK_CLIENT_LIST();
-                debug(LOG_ERR,
-                      "iptables_fw_counters_update(): Could not find %s in client list, this should not happen unless if the gateway crashed",
-                      ip);
-                debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_OUTGOING);
-                iptables_fw_destroy_mention("mangle", CHAIN_OUTGOING, ip);
-                debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_INCOMING);
-                iptables_fw_destroy_mention("mangle", CHAIN_INCOMING, ip);
-            }
-			
-        }
-    }
-    pclose(output);
+				UNLOCK_CLIENT_LIST();
+			} else {
+				UNLOCK_CLIENT_LIST();
+				debug(LOG_ERR,
+					  "iptables_fw_counters_update(): Could not find %s in client list, this should not happen unless if the gateway crashed",
+					  ip);
+				debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_OUTGOING);
+				iptables_fw_destroy_mention("mangle", CHAIN_OUTGOING, ip, NULL);
+				debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_INCOMING);
+				iptables_fw_destroy_mention("mangle", CHAIN_INCOMING, ip, NULL);
+			}
 
-    /* Look for incoming traffic */
-    safe_asprintf(&script, "%s %s", "iptables", "-v -n -x -t mangle -L " CHAIN_INCOMING);
-    iptables_insert_gateway_id(&script);
-    output = popen(script, "r");
-    free(script);
-    if (!output) {
-        debug(LOG_ERR, "popen(): %s", strerror(errno));
-        return -1;
-    }
+		}
+	}
+	pclose(output);
 
-    /* skip the first two lines */
-    while (('\n' != fgetc(output)) && !feof(output)) ;
-    while (('\n' != fgetc(output)) && !feof(output)) ;
-    while (output && !(feof(output))) {
-        rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %*s %15[0-9.]", &counter, ip);
-        if (2 == rc && EOF != rc) {
-            /* Sanity */
-            if (!inet_aton(ip, &tempaddr)) {
-                debug(LOG_WARNING, "I was supposed to read an IP address but instead got [%s] - ignoring it", ip);
-                continue;
-            }
-            debug(LOG_DEBUG, "Read incoming traffic for %s: Bytes=%llu", ip, counter);
-            LOCK_CLIENT_LIST();
-            if ((p1 = client_list_find_by_ip(ip))) {
-                if ((p1->counters.incoming - p1->counters.incoming_history) < counter) {
-                    p1->counters.incoming_delta = p1->counters.incoming_history + counter - p1->counters.incoming;
-                    p1->counters.incoming = p1->counters.incoming_history + counter;
-                    debug(LOG_DEBUG, "%s - Incoming traffic %llu bytes, Updated counter.incoming to %llu bytes", ip, counter, p1->counters.incoming);
-                    p1->counters.last_updated = time(NULL);
-                }
+	/* Look for incoming traffic */
+	safe_asprintf(&script, "%s %s", "iptables", "-v -n -x -t mangle -L " CHAIN_INCOMING);
+	iptables_insert_gateway_id(&script);
+	output = popen(script, "r");
+	free(script);
+	if (!output) {
+		debug(LOG_ERR, "popen(): %s", strerror(errno));
+		return -1;
+	}
 
-            	UNLOCK_CLIENT_LIST();
-            } else {
-            	UNLOCK_CLIENT_LIST();
-                debug(LOG_ERR,
-                      "iptables_fw_counters_update(): Could not find %s in client list, this should not happen unless if the gateway crashed",
-                      ip);
-                debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_OUTGOING);
-                iptables_fw_destroy_mention("mangle", CHAIN_OUTGOING, ip);
-                debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_INCOMING);
-                iptables_fw_destroy_mention("mangle", CHAIN_INCOMING, ip);
-            }
-        }
-    }
-    pclose(output);
+	/* skip the first two lines */
+	while (('\n' != fgetc(output)) && !feof(output)) ;
+	while (('\n' != fgetc(output)) && !feof(output)) ;
+	while (output && !(feof(output))) {
+		rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %*s %15[0-9.]", &counter, ip);
+		if (2 == rc && EOF != rc) {
+			/* Sanity */
+			if (!inet_aton(ip, &tempaddr)) {
+				debug(LOG_WARNING, "I was supposed to read an IP address but instead got [%s] - ignoring it", ip);
+				continue;
+			}
+			debug(LOG_DEBUG, "Read incoming traffic for %s: Bytes=%llu", ip, counter);
+			LOCK_CLIENT_LIST();
+			if ((p1 = client_list_find_by_ip(ip))) {
+				if ((p1->counters.incoming - p1->counters.incoming_history) < counter) {
+					p1->counters.incoming_delta = p1->counters.incoming_history + counter - p1->counters.incoming;
+					p1->counters.incoming = p1->counters.incoming_history + counter;
+					debug(LOG_DEBUG, "%s - Incoming traffic %llu bytes, Updated counter.incoming to %llu bytes", ip, counter, p1->counters.incoming);
+					p1->counters.last_updated = time(NULL);
+				}
 
-    return 1;
+				UNLOCK_CLIENT_LIST();
+			} else {
+				UNLOCK_CLIENT_LIST();
+				debug(LOG_ERR,
+					  "iptables_fw_counters_update(): Could not find %s in client list, this should not happen unless if the gateway crashed",
+					  ip);
+				debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_OUTGOING);
+				iptables_fw_destroy_mention("mangle", CHAIN_OUTGOING, ip, NULL);
+				debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_INCOMING);
+				iptables_fw_destroy_mention("mangle", CHAIN_INCOMING, ip, NULL);
+			}
+		}
+	}
+	pclose(output);
+
+	return 1;
 }

--- a/src/fw_iptables.h
+++ b/src/fw_iptables.h
@@ -67,7 +67,7 @@ typedef enum fw_access_t_ {
 int iptables_fw_init(void);
 
 /** @brief Initializes the authservers table */
-void iptables_fw_set_authservers(void);
+void iptables_fw_set_authservers(void *handle);
 
 /** @brief Clears the authservers table */
 void iptables_fw_clear_authservers(void);
@@ -76,7 +76,7 @@ void iptables_fw_clear_authservers(void);
 int iptables_fw_destroy(void);
 
 /** @brief Helper function for iptables_fw_destroy */
-int iptables_fw_destroy_mention(const char *table, const char *chain, const char *mention);
+int iptables_fw_destroy_mention(const char *table, const char *chain, const char *mention, void *handle);
 
 /** @brief Define the access of a specific client */
 int iptables_fw_access(fw_access_t type, const char *ip, const char *mac, int tag);

--- a/src/xtables-10.h
+++ b/src/xtables-10.h
@@ -1,0 +1,128 @@
+/*
+ * firewall3 - 3rd OpenWrt UCI firewall implementation
+ *
+ *   Copyright (C) 2013 Jo-Philipp Wich <jow@openwrt.org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef __FW3_XTABLES_10_H
+#define __FW3_XTABLES_10_H
+
+extern struct xtables_match *xtables_pending_matches;
+extern struct xtables_target *xtables_pending_targets;
+
+static inline void
+fw3_xt_reset(void)
+{
+	xtables_matches = NULL;
+	xtables_targets = NULL;
+
+	xtables_pending_matches = NULL;
+	xtables_pending_targets = NULL;
+}
+
+
+static inline const char *
+fw3_xt_get_match_name(struct xtables_match *m)
+{
+    if (m->alias)
+        return m->alias(m->m);
+
+    return m->m->u.user.name;
+}
+
+static inline void
+fw3_xt_set_match_name(struct xtables_match *m)
+{
+    if (m->real_name)
+        strcpy(m->m->u.user.name, m->real_name);
+    else
+        strcpy(m->m->u.user.name, m->name);
+}
+
+static inline bool
+fw3_xt_has_match_parse(struct xtables_match *m)
+{
+    return (m->parse || m->x6_parse);
+}
+
+static inline void
+fw3_xt_free_match_udata(struct xtables_match *m)
+{
+    if (m->udata_size)
+    {
+        free(m->udata);
+        m->udata = fw3_alloc(m->udata_size);
+    }
+}
+
+static inline void
+fw3_xt_merge_match_options(struct xtables_globals *g, struct xtables_match *m)
+{
+	if (m->x6_options)
+		g->opts = xtables_options_xfrm(g->orig_opts, g->opts,
+									   m->x6_options, &m->option_offset);
+
+	if (m->extra_opts)
+		g->opts = xtables_merge_options(g->orig_opts, g->opts,
+										m->extra_opts, &m->option_offset);
+}
+
+
+static inline const char *
+fw3_xt_get_target_name(struct xtables_target *t)
+{
+    if (t->alias)
+        return t->alias(t->t);
+
+    return t->t->u.user.name;
+}
+
+static inline void
+fw3_xt_set_target_name(struct xtables_target *t, const char *name)
+{
+    if (t->real_name)
+        strcpy(t->t->u.user.name, t->real_name);
+    else
+        strcpy(t->t->u.user.name, name);
+}
+
+static inline bool
+fw3_xt_has_target_parse(struct xtables_target *t)
+{
+    return (t->parse || t->x6_parse);
+}
+
+static inline void
+fw3_xt_free_target_udata(struct xtables_target *t)
+{
+    if (t->udata_size)
+    {
+        free(t->udata);
+        t->udata = fw3_alloc(t->udata_size);
+    }
+}
+
+static inline void
+fw3_xt_merge_target_options(struct xtables_globals *g, struct xtables_target *t)
+{
+	if (t->x6_options)
+		g->opts = xtables_options_xfrm(g->orig_opts, g->opts,
+		                               t->x6_options, &t->option_offset);
+	else
+		g->opts = xtables_merge_options(g->orig_opts, g->opts,
+		                                t->extra_opts, &t->option_offset);
+}
+
+#endif

--- a/src/xtables-5.h
+++ b/src/xtables-5.h
@@ -1,0 +1,190 @@
+/*
+ * firewall3 - 3rd OpenWrt UCI firewall implementation
+ *
+ *   Copyright (C) 2013 Jo-Philipp Wich <jow@openwrt.org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef __FW3_XTABLES_5_H
+#define __FW3_XTABLES_5_H
+
+static inline void
+fw3_xt_reset(void)
+{
+	xtables_matches = NULL;
+	xtables_targets = NULL;
+}
+
+
+static inline const char *
+fw3_xt_get_match_name(struct xtables_match *m)
+{
+    return m->m->u.user.name;
+}
+
+static inline void
+fw3_xt_set_match_name(struct xtables_match *m)
+{
+    strcpy(m->m->u.user.name, m->name);
+}
+
+static inline bool
+fw3_xt_has_match_parse(struct xtables_match *m)
+{
+    return !!m->parse;
+}
+
+static inline void
+fw3_xt_free_match_udata(struct xtables_match *m)
+{
+    return;
+}
+
+static inline void
+fw3_xt_merge_match_options(struct xtables_globals *g, struct xtables_match *m)
+{
+	g->opts = xtables_merge_options(g->opts, m->extra_opts, &m->option_offset);
+}
+
+
+static inline const char *
+fw3_xt_get_target_name(struct xtables_target *t)
+{
+    return t->t->u.user.name;
+}
+
+static inline void
+fw3_xt_set_target_name(struct xtables_target *t, const char *name)
+{
+    strcpy(t->t->u.user.name, name);
+}
+
+static inline bool
+fw3_xt_has_target_parse(struct xtables_target *t)
+{
+    return !!t->parse;
+}
+
+static inline void
+fw3_xt_free_target_udata(struct xtables_target *t)
+{
+    return;
+}
+
+static inline void
+fw3_xt_merge_target_options(struct xtables_globals *g, struct xtables_target *t)
+{
+	g->opts = xtables_merge_options(g->opts, t->extra_opts, &t->option_offset);
+}
+
+/* xtables api addons */
+
+static inline void
+xtables_option_mpcall(unsigned int c, char **argv, bool invert,
+                      struct xtables_match *m, void *fw)
+{
+	if (m->parse)
+		m->parse(c - m->option_offset, argv, invert, &m->mflags, fw, &m->m);
+}
+
+static inline void
+xtables_option_mfcall(struct xtables_match *m)
+{
+	if (m->final_check)
+		m->final_check(m->mflags);
+}
+
+static inline void
+xtables_option_tpcall(unsigned int c, char **argv, bool invert,
+                      struct xtables_target *t, void *fw)
+{
+	if (t->parse)
+		t->parse(c - t->option_offset, argv, invert, &t->tflags, fw, &t->t);
+}
+
+static inline void
+xtables_option_tfcall(struct xtables_target *t)
+{
+	if (t->final_check)
+		t->final_check(t->tflags);
+}
+
+static inline void
+xtables_rule_matches_free(struct xtables_rule_match **matches)
+{
+	struct xtables_rule_match *mp, *tmp;
+
+	for (mp = *matches; mp;)
+	{
+		tmp = mp->next;
+
+		if (mp->match->m)
+		{
+			free(mp->match->m);
+			mp->match->m = NULL;
+		}
+
+		if (mp->match == mp->match->next)
+		{
+			free(mp->match);
+			mp->match = NULL;
+		}
+
+		free(mp);
+		mp = tmp;
+	}
+
+	*matches = NULL;
+}
+
+static inline int
+xtables_ipmask_to_cidr(const struct in_addr *mask)
+{
+	int bits;
+	uint32_t m;
+
+	for (m = ntohl(mask->s_addr), bits = 0; m & 0x80000000; m <<= 1)
+		bits++;
+
+	return bits;
+}
+
+static inline int
+xtables_ip6mask_to_cidr(const struct in6_addr *mask)
+{
+	int bits = 0;
+	uint32_t a, b, c, d;
+
+	a = ntohl(mask->s6_addr32[0]);
+	b = ntohl(mask->s6_addr32[1]);
+	c = ntohl(mask->s6_addr32[2]);
+	d = ntohl(mask->s6_addr32[3]);
+
+	while (a & 0x80000000U)
+	{
+		a <<= 1;
+		a  |= (b >> 31) & 1;
+		b <<= 1;
+		b  |= (c >> 31) & 1;
+		c <<= 1;
+		c  |= (d >> 31) & 1;
+		d <<= 1;
+
+		bits++;
+	}
+
+	return bits;
+}
+
+#endif


### PR DESCRIPTION
libiptc is the library that is used to communicate with netfilter, the
internal kernel code in charge of firewalling and packet filtering. This
code and iptables were written by Paul "Rusty" Russell. iptables was
developed using libiptc calls to get the job done.

Signed-off-by: ZengFei Zhang <zhangzengfei@kunteng.org>