### PR TITLE
Tune up .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
+dist: trusty
+sudo: false
 language: c
 
 compiler:
   - gcc
 
-install: 
-  - sudo -E apt-add-repository -y ppa:linuxjedi/ppa
-  - sudo apt-get update || true
-  - sudo apt-get install build-essential
-  - sudo apt-get install libjson-c-dev libevent-dev
+addons:
+  apt:
+    sources:
+    - sourceline: 'ppa:linuxjedi/ppa'
+    packages:
+    - build-essential
+    - libjson-c-dev
+    - libevent-dev
 
 script:
   - cmake .


### PR DESCRIPTION
- switch to Trusty as Precise doesn't have `libjson-c-dev` package
- set `sudo: false` and use APT addon for package management