### PR TITLE
fw3_iptc.c: remove unnecessary header includers "libubox/list.h".

### DIFF
--- a/src/fw3_iptc.c
+++ b/src/fw3_iptc.c
@@ -42,7 +42,6 @@
 #include <sys/utsname.h>
 
 #include <xtables.h>
-#include <libubox/list.h>
 
 #include "fw3_iptc.h"
 #include "debug.h"


### PR DESCRIPTION
Signed-off-by: ZengFei Zhang <zhangzengfei@kunteng.org>