### PR TITLE
Update client_list.c

### DIFF
--- a/src/client_list.c
+++ b/src/client_list.c
@@ -197,7 +197,7 @@ offline_client_list_add(const char *ip, const char *mac)
 	curclient->last_login 	= time(NULL);
 	curclient->first_login 	= time(NULL);
 	curclient->client_type 	= 0;
-	curclient->hit_counts 	= 1;
+	curclient->hit_counts 	= 0;
 	curclient->temp_passed 	= 0;
 
 	offline_client_list_insert_client(curclient);


### PR DESCRIPTION
http.c  ->  _special_process  的函数中针对ios系统会有 hit_counts > 2 的判断，并回复含有Success的302页面；
ios系统有时会短时间内连续发送两次captive.apple.com请求，如果此处初始为1，每次请求hit_counts++，第二次请求hit_counts=3，此时hit_counts>2; 则会回复带有Success的302页面；此时ios系统检测到success，则会显示出wifi连接标志，并且将不再弹portal页。