### PR TITLE
May be use an uninitialized pointer

### DIFF
--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -887,7 +887,7 @@ iptables_fw_init(void)
 	/* Insert at the beginning */
 	iptables_do_append_command(handle, "-t filter -I FORWARD -i %s -j " CHAIN_TO_INTERNET, config->gw_interface);
 
-	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -m state --state INVALID -j DROP");
+	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET " -m conntrack --ctstate INVALID -j DROP");
 
 	/* TCPMSS rule for PPPoE */
 	iptables_do_append_command(handle, "-t filter -A " CHAIN_TO_INTERNET

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -196,7 +196,7 @@ done:
 static void serve_403_http(const char *address, const t_http_server *http_server) {
 	struct event_base *base;
 	struct evhttp *http;
-	struct evhttp_bound_socket *handle;
+	struct evhttp_bound_socket *handle = NULL;
 
 	base = event_base_new();
 	if (!base) {


### PR DESCRIPTION
The function serve_403_http in src/http_server.c.
When "http = evhttp_new(base);" failed.
