### PR TITLE
强制选中libopenssl中的某些模块

### DIFF
--- a/package/apfree_wifidog/Makefile
+++ b/package/apfree_wifidog/Makefile
@@ -28,7 +28,7 @@ define Package/$(PKG_NAME)
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+zlib +iptables-mod-extra +iptables-mod-ipopt +kmod-ipt-nat +iptables-mod-nat-extra \
-           +libpthread +libopenssl +libjson-c +ipset +libip4tc +libevent2 +libevent2-openssl \
+           +libpthread +libopenssl +@OPENSSL_WITH_EC +@OPENSSL_WITH_DEPRECATED +@OPENSSL_WITH_PSK +libjson-c +ipset +libip4tc +libevent2 +libevent2-openssl \
 		   +fping +libmosquitto +libuci
   TITLE:=Apfree's wireless captive portal solution
   URL:=http://www.kunteng.org


### PR DESCRIPTION
如若未选中这些模块，在运行wifidog时会报找不到ssl库的某些符号
Error relocating /usr/lib/libmosquitto.so.1: SSL_CTX_set_psk_client_callback: symbol not found
Error relocating /usr/lib/libmosquitto.so.1: ERR_remove_state: symbol not found
Error relocating /usr/bin/wifidog: EC_KEY_new_by_curve_name: symbol not found
