### PR TITLE
Signed-off-by: jianhuizhao <809205580@qq.com>

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -9,3 +9,6 @@ Thank you to all contributors:
 [caizhibang](https://github.com/caizhibang)
 
 [zenghi](https://github.com/zenghi)
+
+[jianhuizhao](https://github.com/809205580)
+

--- a/package/apfree_wifidog/Makefile
+++ b/package/apfree_wifidog/Makefile
@@ -28,7 +28,7 @@ define Package/$(PKG_NAME)
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+zlib +iptables-mod-extra +iptables-mod-ipopt +kmod-ipt-nat +iptables-mod-nat-extra \
-           +libpthread +libopenssl +libjson-c +ipset +libip4tc +libevent2 +libevent2-openssl \
+           +libpthread +libopenssl +@OPENSSL_WITH_EC +@OPENSSL_WITH_DEPRECATED +@OPENSSL_WITH_PSK +libjson-c +ipset +libip4tc +libevent2 +libevent2-openssl \
 		   +fping +libmosquitto +libuci
   TITLE:=Apfree's wireless captive portal solution
   URL:=http://www.kunteng.org


### PR DESCRIPTION
These features of the libopenssl must be dependent by wifidog.
    elliptic curve support
    Include deprecated APIs
    Enable PSK support

Otherwise, if these features are not selected, the following error will occurs when running wifidog:
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_new_by_curve_name: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_dup: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: ECDH_compute_key: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_POINT_new: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_POINT_free: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EVP_PKEY_set1_EC_KEY: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: ECDSA_verify: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_set_group: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_GROUP_get_degree: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_new: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_free: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_get_conv_form: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_GROUP_get_curve_name: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_POINT_point2oct: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_METHOD_get_field_type: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_GROUP_method_of: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_get0_group: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_GROUP_new_by_curve_name: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_set_private_key: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_generate_key: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_curve_nist2nid: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_up_ref: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_POINT_oct2point: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_get0_private_key: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_get0_public_key: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_GROUP_free: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_KEY_set_public_key: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: EC_POINT_copy: symbol not found
Error relocating /usr/lib/libssl.so.1.0.0: ECDSA_sign: symbol not found
Error relocating /usr/lib/libmosquitto.so.1: SSL_CTX_set_psk_client_callback: symbol not found
Error relocating /usr/lib/libmosquitto.so.1: ERR_remove_state: symbol not found
Error relocating /usr/bin/wifidog: EC_KEY_new_by_curve_name: symbol not found