### PR TITLE
event_assign 事件只执行一次，从EV_PERSIST改为0。

### DIFF
--- a/src/https_server.c
+++ b/src/https_server.c
@@ -418,7 +418,7 @@ static int https_redirect (char *gw_ip,  t_https_server *https_server) {
 	check_internet_available(popular_server);
 	check_auth_server_available();
 
-	event_assign(&timeout, base, -1, EV_PERSIST, schedule_work_cb, (void*) &timeout);
+	event_assign(&timeout, base, -1, 0, schedule_work_cb, (void*) &timeout);
 	evutil_timerclear(&tv);
 	tv.tv_sec = config_get_config()->checkinterval;
     event_add(&timeout, &tv);


### PR DESCRIPTION
event_assign 事件只执行一次，从EV_PERSIST改为0。