### PR TITLE
Signed-off-by: wenchangshou <wenchangshou>

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -17,3 +17,5 @@ Thank you to all contributors:
 [LiuQiQuan](https://github.com/tea4go)
 
 [GuYingChun](https://github.com/RuiChen1113)
+
+[wenchangshou2](https://github.com/wenchangshou2)

--- a/package/apfree_wifidog/files/wifidog.init
+++ b/package/apfree_wifidog/files/wifidog.init
@@ -175,7 +175,7 @@ prepare_wifidog_conf() {
 		$set_no_auth
 
 		$set_apple_cna
-		
+
 		$set_update_domain_interval
  	
 		$set_dns_timeout


### PR DESCRIPTION
wifidog.init 178行有一个空格，会造成程序启动错误